### PR TITLE
feat(integrations): Notion select database to sync

### DIFF
--- a/apps/lead-rosetta/docs/integrations/notion.md
+++ b/apps/lead-rosetta/docs/integrations/notion.md
@@ -38,7 +38,8 @@ Without this step, the integration cannot read or sync the database.
 ## 5. Connect in Lead Rosetta
 
 1. In **Dashboard → Integrations**, select **Notion**.
-2. Paste your **API key** and **Database ID**.
-3. Click **Connect Notion**.
+2. Paste your **API key**.
+3. Click **Load databases** to fetch your Notion databases, then select the database to sync from the dropdown. If your database is not in the list, paste its **Database ID** in the field below (see step 3 for how to get it).
+4. Click **Connect Notion**.
 
 After connecting, use **Sync to dashboard** to pull rows from the database into your dashboard clients list.

--- a/apps/lead-rosetta/src/lib/server/notion.ts
+++ b/apps/lead-rosetta/src/lib/server/notion.ts
@@ -48,6 +48,37 @@ export type NotionDatabaseOption = { id: string; title: string };
 export type NotionPropertySchema = { name: string; type: string };
 
 /**
+ * Get the title of the connected Notion database for display (e.g. Integrations page).
+ * Returns null if not connected or API fails (e.g. token revoked).
+ */
+export async function getNotionDatabaseTitle(
+	userId: string
+): Promise<{ title: string; databaseId: string } | null> {
+	const config = await getNotionConfig(userId);
+	if (!config) return null;
+	const { apiKey, databaseId } = config;
+	try {
+		const res = await fetch(`https://api.notion.com/v1/databases/${databaseId}`, {
+			headers: {
+				Authorization: `Bearer ${apiKey}`,
+				'Notion-Version': '2022-06-28',
+				'Content-Type': 'application/json'
+			}
+		});
+		if (!res.ok) return null;
+		const data = (await res.json()) as { title?: Array<{ plain_text?: string }> };
+		const titleArr = data.title;
+		const title =
+			titleArr?.length && titleArr[0]?.plain_text !== undefined
+				? titleArr[0].plain_text
+				: 'Untitled';
+		return { title: title || 'Untitled', databaseId };
+	} catch {
+		return null;
+	}
+}
+
+/**
  * Fetch Notion database schema (property names and types) for the connected database.
  * Used by the Integrations "Map headers" popup.
  */

--- a/apps/lead-rosetta/src/routes/dashboard/integrations/+page.server.ts
+++ b/apps/lead-rosetta/src/routes/dashboard/integrations/+page.server.ts
@@ -19,6 +19,7 @@ import {
 	listProspects as listNotionProspects,
 	listNotionDatabases,
 	getNotionDatabaseSchema,
+	getNotionDatabaseTitle,
 	NOTION_FIELD_KEYS
 } from '$lib/server/notion';
 import { upsertProspect } from '$lib/server/prospects';
@@ -43,7 +44,27 @@ export const load: PageServerLoad = async ({ cookies }) => {
 	const gmailConnected = !!(gmailTokens?.refresh_token);
 	const gmailEmail = gmailTokens?.email ?? null;
 	const notionFieldKeys = NOTION_FIELD_KEYS;
-	return { plan, connections, canConnect: canConnectCrm(plan), helpDocs, gmailConnected, gmailEmail, notionFieldKeys };
+
+	let notionDatabaseId: string | null = null;
+	let notionDatabaseTitle: string | null = null;
+	const notionConn = await getCrmConnection(user.id, 'notion');
+	if (notionConn?.databaseId) {
+		notionDatabaseId = notionConn.databaseId;
+		const titleResult = await getNotionDatabaseTitle(user.id);
+		if (titleResult) notionDatabaseTitle = titleResult.title;
+	}
+
+	return {
+		plan,
+		connections,
+		canConnect: canConnectCrm(plan),
+		helpDocs,
+		gmailConnected,
+		gmailEmail,
+		notionFieldKeys,
+		notionDatabaseId,
+		notionDatabaseTitle
+	};
 };
 
 export const actions: Actions = {

--- a/apps/lead-rosetta/src/routes/dashboard/integrations/+page.svelte
+++ b/apps/lead-rosetta/src/routes/dashboard/integrations/+page.svelte
@@ -27,6 +27,12 @@
 	const gmailConnected = $derived(data.gmailConnected ?? false);
 	const gmailEmail = $derived(data.gmailEmail ?? null);
 	const notionConnected = $derived(connections.find((c) => c.provider === 'notion')?.connected ?? false);
+	const notionDatabaseId = $derived(data.notionDatabaseId ?? null);
+	const notionDatabaseTitle = $derived(data.notionDatabaseTitle ?? null);
+	function truncateNotionId(id: string | null): string {
+		if (!id) return '—';
+		return id.length > 16 ? `${id.slice(0, 8)}…${id.slice(-4)}` : id;
+	}
 	const hubspotConnected = $derived(connections.find((c) => c.provider === 'hubspot')?.connected ?? false);
 	const ghlConnected = $derived(connections.find((c) => c.provider === 'gohighlevel')?.connected ?? false);
 	const pipedriveConnected = $derived(connections.find((c) => c.provider === 'pipedrive')?.connected ?? false);
@@ -57,8 +63,13 @@
 	let selectedNotionDatabaseId = $state('');
 	/** Notion: manual database ID paste (overrides select when non-empty) */
 	let notionManualDatabaseId = $state('');
-	/** Notion: effective database ID for submit (manual paste overrides select when non-empty) */
-	let notionDatabaseIdForSubmit = $derived(notionManualDatabaseId.trim() || selectedNotionDatabaseId);
+	/** Notion: effective database ID for submit (manual paste overrides select when non-empty). Normalize Select value (string or { value }) for form submit. */
+	let notionDatabaseIdForSubmit = $derived(
+		notionManualDatabaseId.trim() ||
+			(typeof selectedNotionDatabaseId === 'string'
+				? selectedNotionDatabaseId
+				: (selectedNotionDatabaseId as { value?: string })?.value ?? '')
+	);
 	/** Notion (edit mode): databases list when editing credentials */
 	let notionEditDatabases = $state<{ id: string; title: string }[]>([]);
 	let notionEditDatabasesLoading = $state(false);
@@ -478,12 +489,12 @@
 										</div>
 									</div>
 									<div class="space-y-2">
-										<Label for="notion-databaseId-connected">Database ID</Label>
+										<Label for="notion-databaseId-connected">Synced database</Label>
 										<div class="flex gap-1">
 											<input
 												id="notion-databaseId-connected"
-												type={showConnectedKeys ? 'text' : 'password'}
-												value="••••••••••••••••••••"
+												type="text"
+												value={showConnectedKeys ? (notionDatabaseId ?? '') : (notionDatabaseTitle || truncateNotionId(notionDatabaseId) || '—')}
 												disabled
 												readonly
 												class="border-input bg-background flex h-9 min-w-0 flex-1 rounded-md border px-3 py-1 font-mono text-sm outline-none disabled:cursor-not-allowed disabled:opacity-50"
@@ -491,7 +502,7 @@
 											<button
 												type="button"
 												onclick={() => (showConnectedKeys = !showConnectedKeys)}
-												aria-label={showConnectedKeys ? 'Hide Database ID' : 'Show Database ID'}
+												aria-label={showConnectedKeys ? 'Show database name' : 'Show database ID'}
 												class="inline-flex size-9 shrink-0 items-center justify-center rounded-md text-sm font-medium hover:bg-accent hover:text-accent-foreground"
 											>
 												{#if showConnectedKeys}
@@ -501,6 +512,9 @@
 												{/if}
 											</button>
 										</div>
+										{#if !showConnectedKeys && notionDatabaseId}
+											<p class="text-xs text-muted-foreground">ID: {truncateNotionId(notionDatabaseId)}</p>
+										{/if}
 									</div>
 								</div>
 									<Button
@@ -683,7 +697,8 @@
 									/>
 								</div>
 								<div class="space-y-2">
-									<Label for="notion-database-select">Database</Label>
+									<Label for="notion-database-select">Select database to sync</Label>
+									<p class="text-xs text-muted-foreground">Select the Notion database that will power your dashboard clients list. This database will be used for syncing contacts to Dashboard → Prospects.</p>
 									{#if notionDatabases.length > 0}
 										<Select.Root type="single" bind:value={selectedNotionDatabaseId}>
 											<Select.Trigger id="notion-database-select" class="w-full font-mono text-sm">


### PR DESCRIPTION
Fixes #8

## Summary
- Expose `notionDatabaseId` and `notionDatabaseTitle` in integrations page load via `getNotionDatabaseTitle()`.
- Show current synced database (title or truncated ID) when Notion is connected; eye toggle reveals full ID.
- Connect flow: explicit "Select database to sync" label and short description.
- Connect form: normalize `databaseId` submit value for Select (string or object).
- Help doc: step 5 updated to mention Load databases and selecting from the list.

## Files changed
- `apps/lead-rosetta/src/lib/server/notion.ts` – add `getNotionDatabaseTitle(userId)`
- `apps/lead-rosetta/src/routes/dashboard/integrations/+page.server.ts` – load and return Notion DB info
- `apps/lead-rosetta/src/routes/dashboard/integrations/+page.svelte` – connected state display, connect copy, submit normalization
- `apps/lead-rosetta/docs/integrations/notion.md` – connect steps
