### PR TITLE
Landing: single case study (glass repair) only, expanded

### DIFF
--- a/apps/landing/src/lib/content/case-studies.ts
+++ b/apps/landing/src/lib/content/case-studies.ts
@@ -5,58 +5,21 @@
 
 export const caseStudyList = [
   {
-    slug: "voice-ai-healthcare-toronto",
-    title: "Voice AI for a Toronto Healthcare Practice",
-    industry: "Healthcare",
-    location: "Toronto, Ontario",
-    outcome: "24/7 call answering; zero missed appointments.",
-    challenge:
-      "The practice missed after-hours and lunch-hour calls, losing potential patients to voicemail and competitors.",
-    solutions:
-      "We deployed a Voice AI system that answers every call 24/7, qualifies callers, and books appointments into their calendar (Voice AI platform, Google Calendar, Cal.com).",
-    stats: [
-      "Before: 20+ missed calls per week → After: Every call answered; leads captured and appointments booked.",
-      "Over 100+ additional bookings made in 3 months.",
-      "Zero missed appointments from call handling.",
-      "15+ hours saved monthly on phone tag.",
-    ],
-    testimonial: null,
-    cta: "Book a free strategy call",
-    href: "/contact",
-  },
-  {
-    slug: "automation-gta-contractor",
-    title: "Automation for a GTA Contractor",
-    industry: "Construction",
-    location: "Greater Toronto Area",
-    outcome: "15+ hours saved weekly on follow-ups and invoicing.",
-    challenge:
-      "Manual follow-ups and invoice reminders consumed 15–20 hours per week; leads and payments were delayed.",
-    solutions:
-      "We built automated workflows for lead nurturing, appointment reminders, and invoice follow-ups, with CRM and calendar integration (Google Workspace, CRM, email automation).",
-    stats: [
-      "Before: Manual follow-up and chasing invoices → After: Automated sequences and payment reminders.",
-      "15+ hours saved weekly.",
-      "Faster lead response and improved cash flow.",
-    ],
-    testimonial: null,
-    cta: "Book a free strategy call",
-    href: "/contact",
-  },
-  {
     slug: "website-seo-toronto-window-glass-repair",
     title: "Website & SEO for a Toronto Window Glass Repair Business",
     industry: "Window & Glass Repair",
     location: "Toronto & GTA",
-    outcome: "Recovered from a compromised site; stronger local rankings, clean SEO, and improved Google Business Profile.",
+    outcome:
+      "Recovered from a compromised site; stronger local rankings, clean SEO, improved Google Business Profile, and a professional site that converts.",
     challenge:
-      "The owner reported his website wasn't ranking. We discovered the blog had been compromised: it was full of gambling, crypto, and other unrelated spam content. That toxic content dragged his SEO and local visibility down and hurt his business.",
+      "The owner (OhMyGlass) reported his website wasn't ranking and didn't represent his business. We audited the site and found the blog had been compromised: it was full of gambling, crypto, and other unrelated spam content. That toxic content dragged his SEO and local visibility down, confused potential customers, and hurt trust. His previous web providers had left the site vulnerable and never addressed the hack.",
     solutions:
-      "We overhauled the website: removed all compromised and spam content, rebuilt the site for speed and trust, improved on-page and technical SEO, and optimized his Google Business Profile (GBP). The site is now clean, relevant, and built to rank for Toronto and GTA glass repair searches.",
+      "We did a full recovery and rebuild: removed all compromised and spam content, secured the site, and rebuilt it for speed and trust. We improved on-page and technical SEO (titles, meta, structure, Core Web Vitals), optimized his Google Business Profile (GBP) for Toronto and GTA glass repair searches, and gave him a clear, professional presence (ohmyglass.ca) that reflects his services: emergency glass repair, window replacement, and mirror installation across Toronto, Etobicoke, and Scarborough.",
     stats: [
-      "Before: Compromised blog (gambling/crypto spam); SEO dragged down → After: Clean site, no spam; improved local SEO and GBP.",
-      "Site recovered from compromise; measurable improvement in local search visibility and organic traffic.",
-      "Cleaner, trustworthy presence and more leads from search.",
+      "Before: Compromised blog (gambling/crypto spam); SEO dragged down; no clear local positioning → After: Clean site, no spam; improved local SEO and GBP.",
+      "Site fully recovered from compromise; measurable improvement in local search visibility and organic traffic.",
+      "Clear, trustworthy presence aligned with real services; more qualified leads from search.",
+      "Google Business Profile optimized so local searchers can find and contact the business reliably.",
     ],
     testimonial: null,
     cta: "Book a free strategy call",

--- a/apps/landing/src/lib/content/seo.ts
+++ b/apps/landing/src/lib/content/seo.ts
@@ -137,9 +137,9 @@ export const seoPages: Record<string, PageSeo> = {
     canonicalPath: "/ontario-ai-automation",
   },
   "/case-studies": {
-    title: "Case Studies | Voice AI, Automation & Website Results | Ed & Sy Toronto",
+    title: "Case Studies | Voice AI and Website & SEO for Toronto Businesses | Ed & Sy Toronto",
     description:
-      "Toronto case studies: Voice AI for healthcare, automation for contractors, website & SEO for window glass repair. Real outcomes.",
+      "Toronto case study: website & SEO for a window glass repair business. Recovered from a compromised site; stronger local rankings, clean SEO, and more leads.",
     canonicalPath: "/case-studies",
   },
   "/blog": {

--- a/apps/landing/src/lib/content/site.ts
+++ b/apps/landing/src/lib/content/site.ts
@@ -250,19 +250,10 @@ export const processStats = [
 /** Case studies (homepage): add real entries as they become available */
 export const caseStudies = [
   {
-    title: "Voice AI for a Toronto healthcare practice",
-    outcome: "24/7 call answering; zero missed appointments.",
-    cta: "Learn how",
-  },
-  {
-    title: "Automation for a GTA contractor",
-    outcome: "15+ hours saved weekly on follow-ups and invoicing.",
-    cta: "See results",
-  },
-  {
     title: "Website & SEO for a Toronto window glass repair business",
-    outcome: "Stronger local rankings, more organic traffic, and more leads from search.",
-    cta: "Read more",
+    outcome:
+      "Recovered a compromised site, strengthened local rankings and Google Business Profile, and built a clean, professional site that brings in more leads from search.",
+    cta: "Read case study",
   },
 ] as const;
 

--- a/apps/landing/src/routes/case-studies/+page.svelte
+++ b/apps/landing/src/routes/case-studies/+page.svelte
@@ -23,7 +23,7 @@
     </nav>
     <h1 class="typography-h1 mb-5">Case Studies</h1>
     <p class="typography-lead max-w-2xl">
-      See how Toronto and Ontario businesses use our Voice AI, automation, and website solutions. Real results and client outcomes.
+      Real results for Toronto and GTA businesses. Our case study shows how we recovered a window glass repair site from compromise and built a clean, ranking presence.
     </p>
   </div>
 </section>

--- a/apps/landing/src/routes/case-studies/[slug]/+page.svelte
+++ b/apps/landing/src/routes/case-studies/[slug]/+page.svelte
@@ -81,18 +81,20 @@
   </div>
 </section>
 
-<section class="py-12 md:py-16 bg-background">
-  <div class="max-w-6xl mx-auto px-6 lg:px-8">
-    <p class="text-muted-foreground mb-6">Explore more case studies:</p>
-    <ul class="space-y-3">
-      {#each caseStudyList.filter((s) => s.slug !== study.slug) as other}
-        <li>
-          <a href="/case-studies/{other.slug}" class="text-primary hover:underline font-medium">
-            {other.title}
-          </a>
-          <span class="text-muted-foreground text-sm"> — {other.industry}</span>
-        </li>
-      {/each}
-    </ul>
-  </div>
-</section>
+{#if caseStudyList.filter((s) => s.slug !== study.slug).length > 0}
+  <section class="py-12 md:py-16 bg-background">
+    <div class="max-w-6xl mx-auto px-6 lg:px-8">
+      <p class="text-muted-foreground mb-6">Explore more case studies:</p>
+      <ul class="space-y-3">
+        {#each caseStudyList.filter((s) => s.slug !== study.slug) as other}
+          <li>
+            <a href="/case-studies/{other.slug}" class="text-primary hover:underline font-medium">
+              {other.title}
+            </a>
+            <span class="text-muted-foreground text-sm"> — {other.industry}</span>
+          </li>
+        {/each}
+      </ul>
+    </div>
+  </section>
+{/if}

--- a/apps/landing/static/sitemap.xml
+++ b/apps/landing/static/sitemap.xml
@@ -79,20 +79,6 @@
   </url>
 
   <url>
-    <loc>https://ednsy.com/case-studies/voice-ai-healthcare-toronto</loc>
-    <lastmod>2026-02-22</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-
-  <url>
-    <loc>https://ednsy.com/case-studies/automation-gta-contractor</loc>
-    <lastmod>2026-02-22</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-
-  <url>
     <loc>https://ednsy.com/case-studies/website-seo-toronto-window-glass-repair</loc>
     <lastmod>2026-02-22</lastmod>
     <changefreq>monthly</changefreq>


### PR DESCRIPTION
Fixes #12

## Summary
Landing site now has a single case study (window glass repair / OhMyGlass). Removed the two placeholder case studies (Voice AI healthcare, GTA contractor) and expanded the glass repair story.

## Changes
- **case-studies.ts**: Only glass repair entry; expanded challenge, solutions, stats, outcome (OhMyGlass, ohmyglass.ca, services, areas).
- **site.ts**: Homepage `caseStudies` reduced to one entry with updated outcome and CTA.
- **seo.ts**: Case studies page title/description updated for single case study.
- **case-studies/+page.svelte**: Intro copy updated.
- **case-studies/[slug]/+page.svelte**: "Explore more case studies" section only shown when other studies exist.
- **sitemap.xml**: Removed URLs for deleted case study slugs.
