### PR TITLE
Approved prospect: Send Demo button at top and email icon in table row

### DIFF
--- a/apps/lead-rosetta/src/lib/components/prospects/prospect-row-actions-cell.svelte
+++ b/apps/lead-rosetta/src/lib/components/prospects/prospect-row-actions-cell.svelte
@@ -1,13 +1,19 @@
 <script lang="ts">
-	import { Sparkles, LoaderCircle } from 'lucide-svelte';
+	import { applyAction } from '$app/forms';
+	import { invalidateAll } from '$app/navigation';
+	import { Sparkles, LoaderCircle, Mail } from 'lucide-svelte';
 	import { buttonVariants } from '$lib/components/ui/button';
 	import { cn } from '$lib/utils';
 	import * as Tooltip from '$lib/components/ui/tooltip';
+	import * as AlertDialog from '$lib/components/ui/alert-dialog';
 	import DataTableActionsCell from '$lib/components/prospects/data-table-actions-cell.svelte';
+	import { toastSuccess, toastError } from '$lib/toast';
 
 	let {
 		prospectId,
 		showGenerate = false,
+		showSendDemo = false,
+		prospectLabel = '',
 		processing = false,
 		generating = false,
 		onProcessNextStep,
@@ -16,10 +22,13 @@
 		demoJobStatus,
 		showDelete = false,
 		showRestore = false,
-		onRegenerateQueued
+		onRegenerateQueued,
+		onSendDemoSuccess
 	}: {
 		prospectId: string;
 		showGenerate?: boolean;
+		showSendDemo?: boolean;
+		prospectLabel?: string;
 		processing?: boolean;
 		generating?: boolean;
 		onProcessNextStep?: (prospectId: string) => void;
@@ -29,14 +38,102 @@
 		showDelete?: boolean;
 		showRestore?: boolean;
 		onRegenerateQueued?: () => void;
+		onSendDemoSuccess?: () => void;
 	} = $props();
 
 	/** Allow sparkles when in queue so user can re-trigger or see status; only block while actively generating. */
 	const canGenerate = $derived(showGenerate && !generating);
+
+	let sendDemoDialogOpen = $state(false);
+	let sendDemoForm: HTMLFormElement | null = $state(null);
+	let sendingDemo = $state(false);
+
+	function ensureAupInput(formEl: HTMLFormElement | null) {
+		if (!formEl) return;
+		let input = formEl.querySelector<HTMLInputElement>('input[name="aupConfirmed"]');
+		if (!input) {
+			input = document.createElement('input');
+			input.type = 'hidden';
+			input.name = 'aupConfirmed';
+			formEl.appendChild(input);
+		}
+		input.value = 'on';
+	}
+
+	function submitSendDemo() {
+		if (!sendDemoForm || sendingDemo) return;
+		ensureAupInput(sendDemoForm);
+		sendDemoForm.requestSubmit();
+	}
 </script>
 
 <div class="flex items-center justify-end gap-1">
-	{#if showGenerate}
+	{#if showSendDemo}
+		<form
+			bind:this={sendDemoForm}
+			method="POST"
+			action="?/sendDemos"
+			use:enhance={() => {
+				sendingDemo = true;
+				return async ({ result }) => {
+					try {
+						if (result.type === 'success' && result.data && typeof result.data === 'object' && 'success' in result.data && result.data.success) {
+							toastSuccess('Email sent', prospectLabel || prospectId);
+							sendDemoDialogOpen = false;
+							await invalidateAll();
+							onSendDemoSuccess?.();
+						} else if (result.type === 'failure' && result.data?.message) {
+							toastError('Send demo', (result.data as { message?: string }).message);
+							await applyAction(result);
+						}
+					} finally {
+						sendingDemo = false;
+					}
+				};
+			}}
+			class="inline-flex"
+		>
+			<input type="hidden" name="prospectId" value={prospectId} />
+			<AlertDialog.Root bind:open={sendDemoDialogOpen}>
+				<Tooltip.Root>
+					<Tooltip.Trigger asChild let:builder>
+						<button
+							type="button"
+							class={cn(buttonVariants({ variant: 'ghost', size: 'icon' }), 'h-8 w-8 text-muted-foreground hover:text-foreground')}
+							aria-label="Send demo by email"
+							onclick={() => (sendDemoDialogOpen = true)}
+							use:builder.action
+							{...builder.props}
+						>
+							<Mail class="size-4" aria-hidden="true" />
+						</button>
+					</Tooltip.Trigger>
+					<Tooltip.Content side="top" sideOffset={6}>
+						Send demo by email
+					</Tooltip.Content>
+				</Tooltip.Root>
+				<AlertDialog.Content>
+					<AlertDialog.Header>
+						<AlertDialog.Title>Send demo to this client?</AlertDialog.Title>
+						<AlertDialog.Description>
+							An email with the demo link will be sent to {prospectLabel || prospectId}.
+							<br><br>
+							<strong>Sending means you accept the Acceptable Use Policy (AUP).</strong>
+						</AlertDialog.Description>
+					</AlertDialog.Header>
+					<AlertDialog.Footer>
+						<AlertDialog.Cancel disabled={sendingDemo}>Cancel</AlertDialog.Cancel>
+						<AlertDialog.Action type="button" disabled={sendingDemo} onclick={submitSendDemo}>
+							{#if sendingDemo}
+								<LoaderCircle class="mr-2 size-4 animate-spin" aria-hidden="true" />
+							{/if}
+							{sendingDemo ? 'Sending…' : 'Send email'}
+						</AlertDialog.Action>
+					</AlertDialog.Footer>
+				</AlertDialog.Content>
+			</AlertDialog.Root>
+		</form>
+	{:else if showGenerate}
 		<Tooltip.Root>
 			<Tooltip.Trigger
 				type="button"

--- a/apps/lead-rosetta/src/routes/dashboard/prospects/+page.svelte
+++ b/apps/lead-rosetta/src/routes/dashboard/prospects/+page.svelte
@@ -368,9 +368,37 @@ import { clientError } from '$lib/log';
 	let insightsJobPollingActive = $state(false);
 	/** Prospect ID currently running processNextStep (per-row generate icon). */
 	let processNextStepId = $state<string | null>(null);
+	let sendDemosDialogOpen = $state(false);
+	let sendDemosForm: HTMLFormElement | null = $state(null);
+	let sendDemosSubmitting = $state(false);
 	/** Prospect IDs we've just submitted for GBP/Insights so status updates immediately before server responds. */
 	let optimisticGbpProspectIds = $state<Set<string>>(new Set());
 	let optimisticInsightsProspectIds = $state<Set<string>>(new Set());
+
+	/** Approved prospects that have a demo and email (can be sent). */
+	const approvedSendableProspects = $derived(
+		approvedProspects.filter(
+			(p) => (p.demoLink ?? '').trim().length > 0 && (p.email ?? '').trim().length > 0
+		)
+	);
+
+	function ensureAupInput(formEl: HTMLFormElement | null) {
+		if (!formEl) return;
+		let input = formEl.querySelector<HTMLInputElement>('input[name="aupConfirmed"]');
+		if (!input) {
+			input = document.createElement('input');
+			input.type = 'hidden';
+			input.name = 'aupConfirmed';
+			formEl.appendChild(input);
+		}
+		input.value = 'on';
+	}
+
+	function submitSendDemosForm() {
+		if (!sendDemosForm || sendDemosSubmitting) return;
+		ensureAupInput(sendDemosForm);
+		sendDemosForm.requestSubmit();
+	}
 
 	/** Run next step for one prospect (pull GBP, pull insights, or create demo). Used by per-row generate icon. */
 	async function handleProcessNextStep(prospectId: string) {
@@ -908,14 +936,21 @@ import { clientError } from '$lib/log';
 					optimisticGbpIds: optimisticGbpProspectIds,
 					optimisticInsightsIds: optimisticInsightsProspectIds
 				});
+				const showSendDemo =
+					step.filterValue === 'approved' &&
+					!!(p.demoLink ?? '').trim() &&
+					!!(p.email ?? '').trim();
 				const showGenerate =
-					step.filterValue === 'pull_data' ||
-					step.filterValue === 'create_demo' ||
-					step.filterValue === 'retry_demo';
+					!showSendDemo &&
+					(step.filterValue === 'pull_data' ||
+						step.filterValue === 'create_demo' ||
+						step.filterValue === 'retry_demo');
 				const demoStatus = p.demoJob?.status as 'pending' | 'creating' | 'done' | 'failed' | undefined;
 				return renderComponent(ProspectRowActionsCell, {
 					prospectId: p.id,
 					showGenerate,
+					showSendDemo,
+					prospectLabel: p.companyName || p.email || p.id,
 					processing: isRowProcessing(p),
 					generating: processNextStepId === p.id,
 					onProcessNextStep: handleProcessNextStep,
@@ -923,7 +958,8 @@ import { clientError } from '$lib/log';
 					demoJobStatus: demoStatus,
 					showDelete: !p.flagged,
 					showRestore: !!p.flagged,
-					onRegenerateQueued: () => startDemoJobPolling()
+					onRegenerateQueued: () => startDemoJobPolling(),
+					onSendDemoSuccess: () => invalidateAll()
 				});
 			}
 		}
@@ -1078,6 +1114,65 @@ import { clientError } from '$lib/log';
 					role="search"
 					aria-label="Filter prospects"
 				>
+					{#if approvedSendableProspects.length > 0}
+						<form
+							bind:this={sendDemosForm}
+							method="POST"
+							action="?/sendDemos"
+							use:enhance={() => {
+								sendDemosSubmitting = true;
+								return async ({ result }) => {
+									try {
+										if (result.type === 'success' && result.data && typeof result.data === 'object' && 'success' in result.data && result.data.success) {
+											const d = result.data as { sent?: number; total?: number };
+											toastSuccess('Send demo', d.sent != null ? `Email sent to ${d.sent} prospect${d.sent === 1 ? '' : 's'}.` : 'Done.');
+											sendDemosDialogOpen = false;
+											await invalidateAll();
+										} else if (result.type === 'failure' && result.data?.message) {
+											toastError('Send demo', (result.data as { message?: string }).message);
+											await applyAction(result);
+										}
+									} finally {
+										sendDemosSubmitting = false;
+									}
+								};
+							}}
+							class="contents"
+						>
+							{#each approvedSendableProspects as p (p.id)}
+								<input type="hidden" name="prospectId" value={p.id} />
+							{/each}
+							<AlertDialog.Root bind:open={sendDemosDialogOpen}>
+								<AlertDialog.Trigger asChild>
+									{#snippet trigger({ props })}
+										<Button type="button" size="sm" class="h-9" {...props}>
+											<Send class="mr-2 size-4" aria-hidden="true" />
+											Send Demo
+										</Button>
+									{/snippet}
+								</AlertDialog.Trigger>
+								<AlertDialog.Content>
+									<AlertDialog.Header>
+										<AlertDialog.Title>Send demo to approved prospects?</AlertDialog.Title>
+										<AlertDialog.Description>
+											An email with the demo link will be sent to {approvedSendableProspects.length} prospect{approvedSendableProspects.length === 1 ? '' : 's'}.
+											<br><br>
+											<strong>Sending means you accept the Acceptable Use Policy (AUP).</strong>
+										</AlertDialog.Description>
+									</AlertDialog.Header>
+									<AlertDialog.Footer>
+										<AlertDialog.Cancel disabled={sendDemosSubmitting}>Cancel</AlertDialog.Cancel>
+										<AlertDialog.Action type="button" disabled={sendDemosSubmitting} onclick={submitSendDemosForm}>
+											{#if sendDemosSubmitting}
+												<LoaderCircle class="mr-2 size-4 animate-spin" aria-hidden="true" />
+											{/if}
+											{sendDemosSubmitting ? 'Sending…' : 'Send email'}
+										</AlertDialog.Action>
+									</AlertDialog.Footer>
+								</AlertDialog.Content>
+							</AlertDialog.Root>
+						</form>
+					{/if}
 					<!-- Search: theme colors only (no Lead Rosetta overrides) -->
 					<div class="prospects-search relative min-w-0 flex-1 basis-64 sm:max-w-xs">
 						<label for="lr-dash-filter" class="sr-only">Search prospects</label>


### PR DESCRIPTION
Fixes #14

## Summary
- **Send Demo at top**: When there are approved prospects (with demo link and email), a "Send Demo" button appears in the filter bar; clicking opens a confirmation dialog and sends the demo to all approved sendable prospects.
- **Email icon in row**: For table rows in "Approved" next step with demo + email, the actions column shows a Mail icon instead of the Sparkles (generate) icon; clicking opens a dialog to send the demo to that prospect (with AUP confirmation).

## Changes
- `apps/lead-rosetta/src/routes/dashboard/prospects/+page.svelte`: approvedSendableProspects, Send Demo form/dialog in filter bar, actions column passes showSendDemo, prospectLabel, onSendDemoSuccess.
- `apps/lead-rosetta/src/lib/components/prospects/prospect-row-actions-cell.svelte`: showSendDemo, Mail icon, send-demo form and AlertDialog for single prospect.
