### PR TITLE
feat(lead-rosetta): add GBP discovery button on Prospects with 15-min lock

### DIFF
--- a/apps/lead-rosetta/src/lib/server/pullGbpDental.ts
+++ b/apps/lead-rosetta/src/lib/server/pullGbpDental.ts
@@ -9,10 +9,12 @@ import { upsertProspect } from '$lib/server/prospects';
 
 const PLACES_BASE = 'https://places.googleapis.com/v1';
 export const GBP_DENTAL_DAILY_CAP = 25;
+export const GBP_DENTAL_PULL_LOCK_MINUTES = 15;
 /** Only add businesses with fewer than this many reviews (need the most help). */
 const MAX_REVIEWS = 50;
 const TARGET_COUNT = 5;
 const PAGE_SIZE = 20;
+const LAST_PULL_AT_KEY = 'gbp_dental_last_pull_at';
 const GTA_RECT = {
 	rectangle: {
 		low: { latitude: 43.4, longitude: -79.8 },
@@ -40,6 +42,13 @@ export type GbpDentalDailyStats = {
 	dailyCap: number;
 };
 
+export type GbpDentalPullLock = {
+	locked: boolean;
+	remainingSeconds: number;
+	lastPullAt: string | null;
+	lockMinutes: number;
+};
+
 /** How many GBP prospects this user has added today (UTC) and the cap. */
 export async function getGbpDentalDailyStats(userId: string): Promise<GbpDentalDailyStats> {
 	const supabase = getSupabaseAdmin();
@@ -54,6 +63,50 @@ export async function getGbpDentalDailyStats(userId: string): Promise<GbpDentalD
 	return {
 		todayCount: error ? 0 : (count ?? 0),
 		dailyCap: GBP_DENTAL_DAILY_CAP
+	};
+}
+
+export async function getGbpDentalPullLock(userId: string): Promise<GbpDentalPullLock> {
+	const supabase = getSupabaseAdmin();
+	if (!supabase) {
+		return {
+			locked: false,
+			remainingSeconds: 0,
+			lastPullAt: null,
+			lockMinutes: GBP_DENTAL_PULL_LOCK_MINUTES
+		};
+	}
+	const { data, error } = await supabase
+		.from('user_settings')
+		.select('value')
+		.eq('user_id', userId)
+		.eq('key', LAST_PULL_AT_KEY)
+		.maybeSingle();
+	if (error || !data?.value || typeof data.value !== 'string') {
+		return {
+			locked: false,
+			remainingSeconds: 0,
+			lastPullAt: null,
+			lockMinutes: GBP_DENTAL_PULL_LOCK_MINUTES
+		};
+	}
+	const lastPullAt = new Date(data.value as string);
+	if (Number.isNaN(lastPullAt.getTime())) {
+		return {
+			locked: false,
+			remainingSeconds: 0,
+			lastPullAt: null,
+			lockMinutes: GBP_DENTAL_PULL_LOCK_MINUTES
+		};
+	}
+	const lockMs = GBP_DENTAL_PULL_LOCK_MINUTES * 60 * 1000;
+	const elapsedMs = Date.now() - lastPullAt.getTime();
+	const remainingSeconds = Math.max(0, Math.ceil((lockMs - elapsedMs) / 1000));
+	return {
+		locked: remainingSeconds > 0,
+		remainingSeconds,
+		lastPullAt: lastPullAt.toISOString(),
+		lockMinutes: GBP_DENTAL_PULL_LOCK_MINUTES
 	};
 }
 
@@ -172,7 +225,7 @@ export type RunPullGbpDentalResult =
 	| { ok: false; message: string };
 
 /**
- * Run one pull: search dental in GTA, filter no website + fewer reviews, add up to 5 as prospects.
+ * Run one pull: search dental in GTA, filter fewer reviews, add up to 5 as prospects.
  * Respects daily cap and Places API monthly usage.
  */
 export async function runPullGbpDental(userId: string): Promise<RunPullGbpDentalResult> {
@@ -184,6 +237,11 @@ export async function runPullGbpDental(userId: string): Promise<RunPullGbpDental
 	const supabase = getSupabaseAdmin();
 	if (!supabase) {
 		return { ok: false, message: 'Database not configured.' };
+	}
+	const pullLock = await getGbpDentalPullLock(userId);
+	if (pullLock.locked) {
+		const minutes = Math.ceil(pullLock.remainingSeconds / 60);
+		return { ok: false, message: `Lead discovery is locked. Try again in ${minutes} minute${minutes === 1 ? '' : 's'}.` };
 	}
 
 	const { todayCount, dailyCap } = await getGbpDentalDailyStats(userId);
@@ -265,6 +323,15 @@ export async function runPullGbpDental(userId: string): Promise<RunPullGbpDental
 		});
 		if (id && !error) added++;
 	}
+	await supabase.from('user_settings').upsert(
+		{
+			user_id: userId,
+			key: LAST_PULL_AT_KEY,
+			value: new Date().toISOString(),
+			updated_at: new Date().toISOString()
+		},
+		{ onConflict: 'user_id,key' }
+	);
 
 	if (added === 0) {
 		return {

--- a/apps/lead-rosetta/src/routes/dashboard/integrations/+page.server.ts
+++ b/apps/lead-rosetta/src/routes/dashboard/integrations/+page.server.ts
@@ -4,16 +4,7 @@ import { markdownToHtml } from '$lib/markdown';
 import { INTEGRATION_HELP_DOCS, INTEGRATION_IDS } from '$lib/server/integrationHelpDocs';
 import { getSessionFromCookie, getSessionCookieName } from '$lib/server/session';
 import { getPlanForUser } from '$lib/server/stripe';
-import { canConnectCrm } from '$lib/plans';
-import {
-	listCrmConnections,
-	saveCrmConnection,
-	deleteCrmConnection,
-	getCrmConnection,
-	listHubSpotContacts,
-	listGoHighLevelContacts,
-	listPipedriveContacts
-} from '$lib/server/crm';
+import { listCrmConnections, saveCrmConnection, deleteCrmConnection, getCrmConnection } from '$lib/server/crm';
 import { getGmailTokens, deleteGmailTokens } from '$lib/server/gmail';
 import {
 	listProspects as listNotionProspects,
@@ -22,11 +13,12 @@ import {
 	getNotionDatabaseTitle,
 	NOTION_FIELD_KEYS
 } from '$lib/server/notion';
-import { upsertProspect } from '$lib/server/prospects';
+import { insertProspectIfAbsent } from '$lib/server/prospects';
 import {
 	getGbpDentalDailyStats,
 	runPullGbpDental,
-	isPlacesConfiguredForGbp
+	isPlacesConfiguredForGbp,
+	getGbpDentalPullLock
 } from '$lib/server/pullGbpDental';
 
 function loadHelpDocs(): Record<string, string> {
@@ -51,6 +43,7 @@ export const load: PageServerLoad = async ({ cookies }) => {
 	const notionFieldKeys = NOTION_FIELD_KEYS;
 	const { todayCount: gbpDentalTodayCount, dailyCap: gbpDentalDailyCap } =
 		await getGbpDentalDailyStats(user.id);
+	const gbpDentalPullLock = await getGbpDentalPullLock(user.id);
 	const placesApiConfigured = isPlacesConfiguredForGbp();
 
 	let notionDatabaseId: string | null = null;
@@ -65,7 +58,6 @@ export const load: PageServerLoad = async ({ cookies }) => {
 	return {
 		plan,
 		connections,
-		canConnect: canConnectCrm(plan),
 		helpDocs,
 		gmailConnected,
 		gmailEmail,
@@ -74,99 +66,12 @@ export const load: PageServerLoad = async ({ cookies }) => {
 		notionDatabaseTitle,
 		gbpDentalTodayCount,
 		gbpDentalDailyCap,
+		gbpDentalPullLock,
 		placesApiConfigured
 	};
 };
 
 export const actions: Actions = {
-	connectHubSpot: async ({ request, cookies }) => {
-		const cookie = cookies.get(getSessionCookieName());
-		const user = await getSessionFromCookie(cookie);
-		if (!user) return fail(401, { message: 'Sign in required' });
-		const plan = await getPlanForUser(user);
-		if (!canConnectCrm(plan)) return fail(403, { message: 'CRM connection is available on Growth and Agency plans.' });
-		const formData = await request.formData();
-		const apiKey = (formData.get('apiKey') as string)?.trim();
-		if (!apiKey) return fail(400, { message: 'API key required' });
-		const result = await saveCrmConnection(user.id, 'hubspot', apiKey);
-		if (!result.ok) return fail(502, { message: result.error ?? 'Failed to save' });
-		return { success: true, message: 'HubSpot connected.' };
-	},
-	connectGoHighLevel: async ({ request, cookies }) => {
-		const cookie = cookies.get(getSessionCookieName());
-		const user = await getSessionFromCookie(cookie);
-		if (!user) return fail(401, { message: 'Sign in required' });
-		const plan = await getPlanForUser(user);
-		if (!canConnectCrm(plan)) return fail(403, { message: 'CRM connection is available on Growth and Agency plans.' });
-		const formData = await request.formData();
-		const apiKey = (formData.get('apiKey') as string)?.trim();
-		if (!apiKey) return fail(400, { message: 'API key required' });
-		const result = await saveCrmConnection(user.id, 'gohighlevel', apiKey);
-		if (!result.ok) return fail(502, { message: result.error ?? 'Failed to save' });
-		return { success: true, message: 'GoHighLevel connected.' };
-	},
-	disconnectHubSpot: async ({ cookies }) => {
-		const cookie = cookies.get(getSessionCookieName());
-		const user = await getSessionFromCookie(cookie);
-		if (!user) return fail(401, { message: 'Sign in required' });
-		const result = await deleteCrmConnection(user.id, 'hubspot');
-		if (!result.ok) return fail(502, { message: result.error ?? 'Failed to disconnect' });
-		return { success: true, message: 'HubSpot disconnected.' };
-	},
-	disconnectGoHighLevel: async ({ cookies }) => {
-		const cookie = cookies.get(getSessionCookieName());
-		const user = await getSessionFromCookie(cookie);
-		if (!user) return fail(401, { message: 'Sign in required' });
-		const result = await deleteCrmConnection(user.id, 'gohighlevel');
-		if (!result.ok) return fail(502, { message: result.error ?? 'Failed to disconnect' });
-		return { success: true, message: 'GoHighLevel disconnected.' };
-	},
-	syncHubSpot: async ({ cookies }) => {
-		const cookie = cookies.get(getSessionCookieName());
-		const user = await getSessionFromCookie(cookie);
-		if (!user) return fail(401, { message: 'Sign in required' });
-		const plan = await getPlanForUser(user);
-		if (!canConnectCrm(plan)) return fail(403, { message: 'CRM sync is available on Growth and Agency plans.' });
-		const conn = await getCrmConnection(user.id, 'hubspot');
-		if (!conn) return fail(400, { message: 'HubSpot not connected' });
-		const { contacts, error } = await listHubSpotContacts(conn.access_token);
-		if (error) return fail(502, { message: error });
-		let synced = 0;
-		for (const c of contacts) {
-			const { id, error: err } = await upsertProspect(user.id, 'hubspot', c.id, {
-				companyName: c.companyName,
-				email: c.email,
-				website: c.website || undefined,
-				phone: c.phone || undefined,
-				status: 'Prospect'
-			});
-			if (id && !err) synced++;
-		}
-		return { success: true, message: `Synced ${synced} of ${contacts.length} contacts to your dashboard.` };
-	},
-	syncGoHighLevel: async ({ cookies }) => {
-		const cookie = cookies.get(getSessionCookieName());
-		const user = await getSessionFromCookie(cookie);
-		if (!user) return fail(401, { message: 'Sign in required' });
-		const plan = await getPlanForUser(user);
-		if (!canConnectCrm(plan)) return fail(403, { message: 'CRM sync is available on Growth and Agency plans.' });
-		const conn = await getCrmConnection(user.id, 'gohighlevel');
-		if (!conn) return fail(400, { message: 'GoHighLevel not connected' });
-		const { contacts, error } = await listGoHighLevelContacts(conn.access_token);
-		if (error) return fail(502, { message: error });
-		let synced = 0;
-		for (const c of contacts) {
-			const { id, error: err } = await upsertProspect(user.id, 'gohighlevel', c.id, {
-				companyName: c.companyName,
-				email: c.email,
-				website: c.website || undefined,
-				phone: c.phone || undefined,
-				status: 'Prospect'
-			});
-			if (id && !err) synced++;
-		}
-		return { success: true, message: `Synced ${synced} of ${contacts.length} contacts to your dashboard.` };
-	},
 	getNotionDatabases: async ({ request, cookies }) => {
 		const cookie = cookies.get(getSessionCookieName());
 		const user = await getSessionFromCookie(cookie);
@@ -232,52 +137,6 @@ export const actions: Actions = {
 		if (!result.ok) return fail(502, { message: result.error ?? 'Failed to save mapping' });
 		return { success: true, message: 'Field mapping saved.' };
 	},
-	connectPipedrive: async ({ request, cookies }) => {
-		const cookie = cookies.get(getSessionCookieName());
-		const user = await getSessionFromCookie(cookie);
-		if (!user) return fail(401, { message: 'Sign in required' });
-		const plan = await getPlanForUser(user);
-		if (!canConnectCrm(plan)) return fail(403, { message: 'CRM connection is available on Growth and Agency plans.' });
-		const formData = await request.formData();
-		const domain = (formData.get('domain') as string)?.trim();
-		const apiKey = (formData.get('apiKey') as string)?.trim();
-		if (!domain || !apiKey) return fail(400, { message: 'Company domain and API token required' });
-		const stored = `${domain}:${apiKey}`;
-		const result = await saveCrmConnection(user.id, 'pipedrive', stored);
-		if (!result.ok) return fail(502, { message: result.error ?? 'Failed to save' });
-		return { success: true, message: 'Pipedrive connected.' };
-	},
-	disconnectPipedrive: async ({ cookies }) => {
-		const cookie = cookies.get(getSessionCookieName());
-		const user = await getSessionFromCookie(cookie);
-		if (!user) return fail(401, { message: 'Sign in required' });
-		const result = await deleteCrmConnection(user.id, 'pipedrive');
-		if (!result.ok) return fail(502, { message: result.error ?? 'Failed to disconnect' });
-		return { success: true, message: 'Pipedrive disconnected.' };
-	},
-	syncPipedrive: async ({ cookies }) => {
-		const cookie = cookies.get(getSessionCookieName());
-		const user = await getSessionFromCookie(cookie);
-		if (!user) return fail(401, { message: 'Sign in required' });
-		const plan = await getPlanForUser(user);
-		if (!canConnectCrm(plan)) return fail(403, { message: 'CRM sync is available on Growth and Agency plans.' });
-		const conn = await getCrmConnection(user.id, 'pipedrive');
-		if (!conn) return fail(400, { message: 'Pipedrive not connected' });
-		const { contacts, error } = await listPipedriveContacts(conn.access_token);
-		if (error) return fail(502, { message: error });
-		let synced = 0;
-		for (const c of contacts) {
-			const { id, error: err } = await upsertProspect(user.id, 'pipedrive', c.id, {
-				companyName: c.companyName,
-				email: c.email,
-				website: c.website || undefined,
-				phone: c.phone || undefined,
-				status: 'Prospect'
-			});
-			if (id && !err) synced++;
-		}
-		return { success: true, message: `Synced ${synced} of ${contacts.length} contacts to your dashboard.` };
-	},
 	syncNotion: async ({ cookies }) => {
 		const cookie = cookies.get(getSessionCookieName());
 		const user = await getSessionFromCookie(cookie);
@@ -286,18 +145,24 @@ export const actions: Actions = {
 		if (!conn?.databaseId) return fail(400, { message: 'Notion not connected' });
 		const result = await listNotionProspects(user.id);
 		if (result.error) return fail(502, { message: result.message ?? 'Failed to load from Notion' });
-		let synced = 0;
+		let inserted = 0;
+		let skipped = 0;
 		for (const p of result.prospects) {
-			const { id, error: err } = await upsertProspect(user.id, 'notion', p.id, {
+			const r = await insertProspectIfAbsent(user.id, 'notion', p.id, {
 				companyName: p.companyName,
 				email: p.email,
 				website: p.website || undefined,
 				phone: p.phone || undefined,
-				status: p.status || 'Prospect'
+				industry: p.industry || undefined
 			});
-			if (id && !err) synced++;
+			if (r.error) continue;
+			if (r.inserted) inserted++;
+			else skipped++;
 		}
-		return { success: true, message: `Synced ${synced} of ${result.prospects.length} rows from Notion to your dashboard.` };
+		return {
+			success: true,
+			message: `Inserted ${inserted} new row(s); skipped ${skipped} already in your dashboard (${result.prospects.length} total from Notion).`
+		};
 	},
 	/** Save current mapping from form then run sync (single action for the Map headers popup). */
 	syncNotionWithMapping: async ({ request, cookies }) => {
@@ -320,18 +185,24 @@ export const actions: Actions = {
 		if (!saveResult.ok) return fail(502, { message: saveResult.error ?? 'Failed to save mapping' });
 		const result = await listNotionProspects(user.id);
 		if (result.error) return fail(502, { message: result.message ?? 'Failed to load from Notion' });
-		let synced = 0;
+		let inserted = 0;
+		let skipped = 0;
 		for (const p of result.prospects) {
-			const { id, error: err } = await upsertProspect(user.id, 'notion', p.id, {
+			const r = await insertProspectIfAbsent(user.id, 'notion', p.id, {
 				companyName: p.companyName,
 				email: p.email,
 				website: p.website || undefined,
 				phone: p.phone || undefined,
-				status: p.status || 'Prospect'
+				industry: p.industry || undefined
 			});
-			if (id && !err) synced++;
+			if (r.error) continue;
+			if (r.inserted) inserted++;
+			else skipped++;
 		}
-		return { success: true, message: `Synced ${synced} of ${result.prospects.length} rows from Notion to your dashboard.` };
+		return {
+			success: true,
+			message: `Inserted ${inserted} new row(s); skipped ${skipped} already in your dashboard (${result.prospects.length} total from Notion).`
+		};
 	},
 	disconnectGmail: async ({ cookies }) => {
 		const cookie = cookies.get(getSessionCookieName());

--- a/apps/lead-rosetta/src/routes/dashboard/integrations/+page.svelte
+++ b/apps/lead-rosetta/src/routes/dashboard/integrations/+page.svelte
@@ -15,19 +15,23 @@
 	import { goto } from '$app/navigation';
 	import * as Select from '$lib/components/ui/select';
 
-	type IntegrationId = 'notion' | 'hubspot' | 'gohighlevel' | 'pipedrive' | 'gbp-dental';
+	type IntegrationId = 'notion' | 'gbp-dental';
 
 	let { data, form } = $props<{
 		data: PageData;
 		form?: import('./$types').ActionFailure<{ message: string }> & { success?: boolean; message?: string };
 	}>();
-	const plan = $derived(data.plan ?? 'free');
 	const connections = $derived(data.connections ?? []);
-	const canConnect = $derived(data.canConnect ?? false);
 	const gmailConnected = $derived(data.gmailConnected ?? false);
 	const gmailEmail = $derived(data.gmailEmail ?? null);
 	const gbpDentalTodayCount = $derived(data.gbpDentalTodayCount ?? 0);
 	const gbpDentalDailyCap = $derived(data.gbpDentalDailyCap ?? 25);
+	const gbpDentalPullLock = $derived(
+		data.gbpDentalPullLock ?? { locked: false, remainingSeconds: 0, lockMinutes: 15 }
+	);
+	const gbpDentalLockMinutesRemaining = $derived(
+		Math.ceil((gbpDentalPullLock.remainingSeconds ?? 0) / 60)
+	);
 	const placesApiConfigured = $derived(data.placesApiConfigured ?? false);
 	const notionConnected = $derived(connections.find((c) => c.provider === 'notion')?.connected ?? false);
 	const notionDatabaseId = $derived(data.notionDatabaseId ?? null);
@@ -36,20 +40,10 @@
 		if (!id) return '—';
 		return id.length > 16 ? `${id.slice(0, 8)}…${id.slice(-4)}` : id;
 	}
-	const hubspotConnected = $derived(connections.find((c) => c.provider === 'hubspot')?.connected ?? false);
-	const ghlConnected = $derived(connections.find((c) => c.provider === 'gohighlevel')?.connected ?? false);
-	const pipedriveConnected = $derived(connections.find((c) => c.provider === 'pipedrive')?.connected ?? false);
-
 	let selectedId = $state<IntegrationId | null>(null);
-	let syncing = $state<'notion' | 'hubspot' | 'gohighlevel' | 'pipedrive' | 'gbp-dental' | null>(null);
+	let syncing = $state<'notion' | 'gbp-dental' | null>(null);
 	let disconnectNotionOpen = $state(false);
-	let disconnectHubSpotOpen = $state(false);
-	let disconnectGhlOpen = $state(false);
-	let disconnectPipedriveOpen = $state(false);
 	let notionDisconnectForm: HTMLFormElement | null = $state(null);
-	let hubspotDisconnectForm: HTMLFormElement | null = $state(null);
-	let ghlDisconnectForm: HTMLFormElement | null = $state(null);
-	let pipedriveDisconnectForm: HTMLFormElement | null = $state(null);
 	/** Toggle show/hide for masked credential fields when connected */
 	let showConnectedKeys = $state(false);
 	/** When true, credentials are loaded and form is in edit mode; eye reveals actual values */
@@ -141,18 +135,6 @@
 		disconnectNotionOpen = false;
 		notionDisconnectForm?.requestSubmit();
 	}
-	function submitHubSpotDisconnect() {
-		disconnectHubSpotOpen = false;
-		hubspotDisconnectForm?.requestSubmit();
-	}
-	function submitGhlDisconnect() {
-		disconnectGhlOpen = false;
-		ghlDisconnectForm?.requestSubmit();
-	}
-	function submitPipedriveDisconnect() {
-		disconnectPipedriveOpen = false;
-		pipedriveDisconnectForm?.requestSubmit();
-	}
 
 	const integrations = $derived([
 		{
@@ -164,33 +146,9 @@
 			locked: false
 		},
 		{
-			id: 'hubspot' as const,
-			name: 'HubSpot',
-			description: 'Sync contacts from HubSpot. Use a Private App token.',
-			logoSrc: '/integrations/hubspot.png',
-			connected: hubspotConnected,
-			locked: !canConnect
-		},
-		{
-			id: 'gohighlevel' as const,
-			name: 'GoHighLevel',
-			description: 'Sync contacts from GoHighLevel. Sub-Account or Location token.',
-			logoSrc: '/integrations/gohighlevel.jpeg',
-			connected: ghlConnected,
-			locked: !canConnect
-		},
-		{
-			id: 'pipedrive' as const,
-			name: 'Pipedrive',
-			description: 'Sync contacts from Pipedrive. Company domain + API token.',
-			logoSrc: '/integrations/pipedrive.png',
-			connected: pipedriveConnected,
-			locked: !canConnect
-		},
-		{
 			id: 'gbp-dental' as const,
 			name: 'Lead discovery (GBP)',
-			description: 'Pull dental leads from Toronto/GTA (no website, fewer reviews). Max 25 per day.',
+			description: 'Pull dental leads from Toronto/GTA (fewer reviews). Max 25 per day.',
 			logoSrc: '',
 			connected: placesApiConfigured,
 			locked: !placesApiConfigured
@@ -363,19 +321,9 @@
 				<div class="flex min-h-0 min-w-0 flex-1 flex-col lg:col-span-2">
 				{#if selected.locked}
 					<div class="flex flex-col gap-4">
-						{#if selected.id === 'gbp-dental'}
-							<p class="text-sm text-muted-foreground">
-								Google Places API is not configured. Set <code class="rounded bg-muted px-1 py-0.5 text-xs font-mono">GOOGLE_PLACES_API_KEY</code> (or <code class="rounded bg-muted px-1 py-0.5 text-xs font-mono">GOOGLE_MAPS_API_KEY</code>) in your server <code class="rounded bg-muted px-1 py-0.5 text-xs font-mono">.env</code> to pull dental leads.
-							</p>
-						{:else}
-							<p class="text-sm text-muted-foreground">
-								CRM integrations are available on Growth and Agency plans. Upgrade to connect {selected.name} and
-								sync contacts to your dashboard.
-							</p>
-							<div class="mt-auto pt-4">
-								<Button variant="default" href="/dashboard/billing">Upgrade plan</Button>
-							</div>
-						{/if}
+						<p class="text-sm text-muted-foreground">
+							Google Places API is not configured. Set <code class="rounded bg-muted px-1 py-0.5 text-xs font-mono">GOOGLE_PLACES_API_KEY</code> (or <code class="rounded bg-muted px-1 py-0.5 text-xs font-mono">GOOGLE_MAPS_API_KEY</code>) in your server <code class="rounded bg-muted px-1 py-0.5 text-xs font-mono">.env</code> to pull dental leads.
+						</p>
 					</div>
 				{:else if selected.id === 'gbp-dental'}
 					<div class="flex flex-col gap-4">
@@ -385,6 +333,11 @@
 						<p class="text-sm font-medium">
 							Today: {gbpDentalTodayCount} / {gbpDentalDailyCap} leads
 						</p>
+						{#if gbpDentalPullLock.locked}
+							<p class="text-sm text-muted-foreground">
+								Locked for {gbpDentalLockMinutesRemaining} more minute{gbpDentalLockMinutesRemaining === 1 ? '' : 's'}.
+							</p>
+						{/if}
 						<form
 							method="POST"
 							action="?/pullGbpDental"
@@ -407,7 +360,7 @@
 							<Button
 								type="submit"
 								size="sm"
-								disabled={syncing === 'gbp-dental' || gbpDentalTodayCount >= gbpDentalDailyCap}
+								disabled={syncing === 'gbp-dental' || gbpDentalTodayCount >= gbpDentalDailyCap || gbpDentalPullLock.locked}
 							>
 								{#if syncing === 'gbp-dental'}
 									<LoaderCircle class="mr-2 h-4 w-4 animate-spin" />
@@ -787,462 +740,6 @@
 							</div>
 							<div class="mt-auto flex flex-wrap gap-2 pt-2">
 								<Button type="submit" disabled={!notionDatabaseIdForSubmit.trim()}>Connect Notion</Button>
-							</div>
-						</form>
-					{/if}
-				{:else if selected.connected}
-					<!-- CRM connected -->
-					<div class="flex flex-1 flex-col gap-4">
-						{#if selected.id === 'hubspot'}
-							{#if editingCredentials}
-								<form method="POST" action="?/connectHubSpot" use:enhance={() => async ({ result }) => {
-									toastFromActionResult('Connect HubSpot', result, 'HubSpot connected.');
-								}} class="flex flex-col gap-4">
-									<div class="space-y-2">
-										<Label for="hubspot-token-edit">Private App token</Label>
-										<div class="flex gap-1">
-											<input
-												id="hubspot-token-edit"
-												name="apiKey"
-												type={showConnectedKeys ? 'text' : 'password'}
-												bind:value={editValues.apiKey}
-												class="border-input bg-background flex h-9 min-w-0 flex-1 rounded-md border px-3 py-1 font-mono text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
-											/>
-											<button
-												type="button"
-												onclick={() => (showConnectedKeys = !showConnectedKeys)}
-												aria-label={showConnectedKeys ? 'Hide token' : 'Show token'}
-												class="inline-flex size-9 shrink-0 items-center justify-center rounded-md text-sm font-medium hover:bg-accent hover:text-accent-foreground"
-											>
-												{#if showConnectedKeys}
-													<EyeOff class="h-4 w-4" />
-												{:else}
-													<Eye class="h-4 w-4" />
-												{/if}
-											</button>
-										</div>
-									</div>
-									<div class="mt-auto flex flex-wrap gap-2 pt-2">
-										<Button type="submit" size="sm">Save</Button>
-										<Button type="button" variant="ghost" size="sm" onclick={cancelEditingCredentials}>Cancel</Button>
-									</div>
-								</form>
-							{:else}
-								<div class="space-y-4">
-									<div class="space-y-2">
-										<Label for="hubspot-token-connected">Private App token</Label>
-										<div class="flex gap-1">
-											<input
-												id="hubspot-token-connected"
-												type={showConnectedKeys ? 'text' : 'password'}
-												value="••••••••••••••••••••"
-												disabled
-												readonly
-												class="border-input bg-background flex h-9 min-w-0 flex-1 rounded-md border px-3 py-1 font-mono text-sm outline-none disabled:cursor-not-allowed disabled:opacity-50"
-											/>
-											<button
-												type="button"
-												onclick={() => (showConnectedKeys = !showConnectedKeys)}
-												aria-label={showConnectedKeys ? 'Hide token' : 'Show token'}
-												class="inline-flex size-9 shrink-0 items-center justify-center rounded-md text-sm font-medium hover:bg-accent hover:text-accent-foreground"
-											>
-												{#if showConnectedKeys}
-													<EyeOff class="h-4 w-4" />
-												{:else}
-													<Eye class="h-4 w-4" />
-												{/if}
-											</button>
-										</div>
-									</div>
-								</div>
-								<div class="mt-auto flex flex-wrap gap-2 pt-2">
-									<Button type="button" variant="outline" size="sm" disabled={loadingCredentials} onclick={startEditingCredentials}>
-										{#if loadingCredentials}<LoaderCircle class="mr-2 h-4 w-4 animate-spin" />{:else}<Pencil class="mr-2 h-4 w-4" />{/if}
-										Edit key
-									</Button>
-									<form method="POST" action="?/syncHubSpot" use:enhance={() => {
-									syncing = 'hubspot';
-									return async ({ result }) => {
-										syncing = null;
-										toastFromActionResult('Sync HubSpot', result, 'Contacts synced to dashboard.');
-									};
-								}} class="inline">
-										<Button type="submit" size="sm" disabled={syncing !== null}>
-											{#if syncing === 'hubspot'}<LoaderCircle class="mr-2 h-4 w-4 animate-spin" />{:else}<Link2 class="mr-2 h-4 w-4" />{/if}
-											Sync to dashboard
-										</Button>
-									</form>
-									<form bind:this={hubspotDisconnectForm} method="POST" action="?/disconnectHubSpot" use:enhance={() => async ({ result }) => {
-										if (result.type === 'success' && (result.data as { success?: boolean })?.success) {
-											await invalidateAll();
-											toastSuccess('HubSpot disconnected', 'You can reconnect from this page.');
-										} else if (result.type === 'failure') {
-											toastError('Disconnect HubSpot', (result.data as { message?: string })?.message);
-										}
-									}} class="inline">
-										<AlertDialog.Root bind:open={disconnectHubSpotOpen}>
-											<AlertDialog.Trigger><Button variant="ghost" size="sm">Disconnect</Button></AlertDialog.Trigger>
-											<AlertDialog.Content>
-												<AlertDialog.Header>
-													<AlertDialog.Title>Disconnect {selected.name}</AlertDialog.Title>
-													<AlertDialog.Description>Contacts will no longer sync from {selected.name}. You can reconnect at any time.</AlertDialog.Description>
-												</AlertDialog.Header>
-												<AlertDialog.Footer>
-													<AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
-													<AlertDialog.Action onclick={submitHubSpotDisconnect}>Disconnect</AlertDialog.Action>
-												</AlertDialog.Footer>
-											</AlertDialog.Content>
-										</AlertDialog.Root>
-									</form>
-								</div>
-							{/if}
-						{:else if selected.id === 'gohighlevel'}
-							{#if editingCredentials}
-								<form
-									method="POST"
-									action="?/connectGoHighLevel"
-									use:enhance={() => async ({ result }) => {
-										if (result.type === 'success' && (result.data as { success?: boolean })?.success) {
-											editingCredentials = false;
-											editValues = {};
-											showConnectedKeys = false;
-											toastSuccess('Connect GoHighLevel', 'GoHighLevel connected.');
-										} else if (result.type === 'failure') {
-											toastError('Connect GoHighLevel', (result.data as { message?: string })?.message);
-										}
-									}}
-									class="flex flex-col gap-4"
-								>
-									<div class="space-y-2">
-										<Label for="ghl-token-edit">API token</Label>
-										<div class="flex gap-1">
-											<input
-												id="ghl-token-edit"
-												name="apiKey"
-												type={showConnectedKeys ? 'text' : 'password'}
-												bind:value={editValues.apiKey}
-												class="border-input bg-background flex h-9 min-w-0 flex-1 rounded-md border px-3 py-1 font-mono text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
-											/>
-											<button
-												type="button"
-												onclick={() => (showConnectedKeys = !showConnectedKeys)}
-												aria-label={showConnectedKeys ? 'Hide token' : 'Show token'}
-												class="inline-flex size-9 shrink-0 items-center justify-center rounded-md text-sm font-medium hover:bg-accent hover:text-accent-foreground"
-											>
-												{#if showConnectedKeys}<EyeOff class="h-4 w-4" />{:else}<Eye class="h-4 w-4" />{/if}
-											</button>
-										</div>
-									</div>
-									<div class="mt-auto flex flex-wrap gap-2 pt-2">
-										<Button type="submit" size="sm">Save</Button>
-										<Button type="button" variant="ghost" size="sm" onclick={cancelEditingCredentials}>Cancel</Button>
-									</div>
-								</form>
-							{:else}
-								<div class="space-y-4">
-									<div class="space-y-2">
-										<Label for="ghl-token-connected">API token</Label>
-										<div class="flex gap-1">
-											<input
-												id="ghl-token-connected"
-												type={showConnectedKeys ? 'text' : 'password'}
-												value="••••••••••••••••••••"
-												disabled
-												readonly
-												class="border-input bg-background flex h-9 min-w-0 flex-1 rounded-md border px-3 py-1 font-mono text-sm outline-none disabled:cursor-not-allowed disabled:opacity-50"
-											/>
-											<button
-												type="button"
-												onclick={() => (showConnectedKeys = !showConnectedKeys)}
-												aria-label={showConnectedKeys ? 'Hide token' : 'Show token'}
-												class="inline-flex size-9 shrink-0 items-center justify-center rounded-md text-sm font-medium hover:bg-accent hover:text-accent-foreground"
-											>
-												{#if showConnectedKeys}
-													<EyeOff class="h-4 w-4" />
-												{:else}
-													<Eye class="h-4 w-4" />
-												{/if}
-											</button>
-										</div>
-									</div>
-								</div>
-							{/if}
-						{:else}
-							<!-- Pipedrive: domain + API token -->
-							{#if editingCredentials}
-								<form
-									method="POST"
-									action="?/connectPipedrive"
-									use:enhance={() => async ({ result }) => {
-										if (result.type === 'success' && (result.data as { success?: boolean })?.success) {
-											editingCredentials = false;
-											editValues = {};
-											showConnectedKeys = false;
-											toastSuccess('Connect Pipedrive', 'Pipedrive connected.');
-										} else if (result.type === 'failure') {
-											toastError('Connect Pipedrive', (result.data as { message?: string })?.message);
-										}
-									}}
-									class="flex flex-col gap-4"
-								>
-									<div class="space-y-4">
-										<div class="space-y-2">
-											<Label for="pipedrive-domain-edit">Company domain</Label>
-											<div class="flex gap-1">
-												<input
-													id="pipedrive-domain-edit"
-													name="domain"
-													type={showConnectedKeys ? 'text' : 'password'}
-													bind:value={editValues.domain}
-													class="border-input bg-background flex h-9 min-w-0 flex-1 rounded-md border px-3 py-1 font-mono text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
-												/>
-												<button type="button" onclick={() => (showConnectedKeys = !showConnectedKeys)} aria-label={showConnectedKeys ? 'Hide domain' : 'Show domain'} class="inline-flex size-9 shrink-0 items-center justify-center rounded-md text-sm font-medium hover:bg-accent hover:text-accent-foreground">
-													{#if showConnectedKeys}<EyeOff class="h-4 w-4" />{:else}<Eye class="h-4 w-4" />{/if}
-												</button>
-											</div>
-										</div>
-										<div class="space-y-2">
-											<Label for="pipedrive-token-edit">API token</Label>
-											<div class="flex gap-1">
-												<input
-													id="pipedrive-token-edit"
-													name="apiKey"
-													type={showConnectedKeys ? 'text' : 'password'}
-													bind:value={editValues.apiKey}
-													class="border-input bg-background flex h-9 min-w-0 flex-1 rounded-md border px-3 py-1 font-mono text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
-												/>
-												<button type="button" onclick={() => (showConnectedKeys = !showConnectedKeys)} aria-label={showConnectedKeys ? 'Hide token' : 'Show token'} class="inline-flex size-9 shrink-0 items-center justify-center rounded-md text-sm font-medium hover:bg-accent hover:text-accent-foreground">
-													{#if showConnectedKeys}<EyeOff class="h-4 w-4" />{:else}<Eye class="h-4 w-4" />{/if}
-												</button>
-											</div>
-										</div>
-									</div>
-									<div class="mt-auto flex flex-wrap gap-2 pt-2">
-										<Button type="submit" size="sm">Save</Button>
-										<Button type="button" variant="ghost" size="sm" onclick={cancelEditingCredentials}>Cancel</Button>
-									</div>
-								</form>
-							{:else}
-								<div class="space-y-4">
-									<div class="space-y-2">
-										<Label for="pipedrive-domain-connected">Company domain</Label>
-										<div class="flex gap-1">
-											<input
-												id="pipedrive-domain-connected"
-												type={showConnectedKeys ? 'text' : 'password'}
-												value="••••••••••••"
-												disabled
-												readonly
-												class="border-input bg-background flex h-9 min-w-0 flex-1 rounded-md border px-3 py-1 font-mono text-sm outline-none disabled:cursor-not-allowed disabled:opacity-50"
-											/>
-											<button
-												type="button"
-												onclick={() => (showConnectedKeys = !showConnectedKeys)}
-												aria-label={showConnectedKeys ? 'Hide domain' : 'Show domain'}
-												class="inline-flex size-9 shrink-0 items-center justify-center rounded-md text-sm font-medium hover:bg-accent hover:text-accent-foreground"
-											>
-												{#if showConnectedKeys}
-													<EyeOff class="h-4 w-4" />
-												{:else}
-													<Eye class="h-4 w-4" />
-												{/if}
-											</button>
-										</div>
-									</div>
-									<div class="space-y-2">
-										<Label for="pipedrive-token-connected">API token</Label>
-										<div class="flex gap-1">
-											<input
-												id="pipedrive-token-connected"
-												type={showConnectedKeys ? 'text' : 'password'}
-												value="••••••••••••••••••••"
-												disabled
-												readonly
-												class="border-input bg-background flex h-9 min-w-0 flex-1 rounded-md border px-3 py-1 font-mono text-sm outline-none disabled:cursor-not-allowed disabled:opacity-50"
-											/>
-											<button
-												type="button"
-												onclick={() => (showConnectedKeys = !showConnectedKeys)}
-												aria-label={showConnectedKeys ? 'Hide token' : 'Show token'}
-												class="inline-flex size-9 shrink-0 items-center justify-center rounded-md text-sm font-medium hover:bg-accent hover:text-accent-foreground"
-											>
-												{#if showConnectedKeys}
-													<EyeOff class="h-4 w-4" />
-												{:else}
-													<Eye class="h-4 w-4" />
-												{/if}
-											</button>
-										</div>
-									</div>
-								</div>
-							{/if}
-						{/if}
-						{#if selected.id !== 'hubspot' && !editingCredentials}
-						<div class="mt-auto flex flex-wrap gap-2 pt-2">
-							<Button type="button" variant="outline" size="sm" disabled={loadingCredentials} onclick={startEditingCredentials}>
-								{#if loadingCredentials}<LoaderCircle class="mr-2 h-4 w-4 animate-spin" />{:else}<Pencil class="mr-2 h-4 w-4" />{/if}
-								Edit key
-							</Button>
-							<form
-								method="POST"
-								action={selected.id === 'gohighlevel' ? '?/syncGoHighLevel' : '?/syncPipedrive'}
-								use:enhance={() => {
-									syncing = selected.id;
-									return async ({ result }) => {
-										syncing = null;
-										toastFromActionResult(
-											selected.id === 'gohighlevel' ? 'Sync GoHighLevel' : 'Sync Pipedrive',
-											result,
-											'Contacts synced to dashboard.'
-										);
-									};
-								}}
-								class="inline"
-							>
-								<Button type="submit" size="sm" disabled={syncing !== null}>
-									{#if syncing === selected.id}
-										<LoaderCircle class="mr-2 h-4 w-4 animate-spin" />
-									{:else}
-										<Link2 class="mr-2 h-4 w-4" />
-									{/if}
-									Sync to dashboard
-								</Button>
-							</form>
-							{#if selected.id === 'gohighlevel'}
-								<form bind:this={ghlDisconnectForm} method="POST" action="?/disconnectGoHighLevel" use:enhance={() => async ({ result }) => {
-									if (result.type === 'success' && (result.data as { success?: boolean })?.success) {
-										await invalidateAll();
-										toastSuccess('GoHighLevel disconnected', 'You can reconnect from this page.');
-									} else if (result.type === 'failure') {
-										toastError('Disconnect GoHighLevel', (result.data as { message?: string })?.message);
-									}
-								}} class="inline">
-									<AlertDialog.Root bind:open={disconnectGhlOpen}>
-										<AlertDialog.Trigger type="button" class="inline-flex h-8 items-center justify-center rounded-md px-3 text-sm hover:bg-accent hover:text-accent-foreground">
-											Disconnect
-										</AlertDialog.Trigger>
-										<AlertDialog.Content>
-											<AlertDialog.Header>
-												<AlertDialog.Title>Disconnect {selected.name}</AlertDialog.Title>
-												<AlertDialog.Description>
-													Contacts will no longer sync from {selected.name}. You can reconnect at any time.
-												</AlertDialog.Description>
-											</AlertDialog.Header>
-											<AlertDialog.Footer>
-												<AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
-												<AlertDialog.Action onclick={submitGhlDisconnect}>Disconnect</AlertDialog.Action>
-											</AlertDialog.Footer>
-										</AlertDialog.Content>
-									</AlertDialog.Root>
-								</form>
-							{:else}
-								<form bind:this={pipedriveDisconnectForm} method="POST" action="?/disconnectPipedrive" use:enhance={() => async ({ result }) => {
-									if (result.type === 'success' && (result.data as { success?: boolean })?.success) {
-										await invalidateAll();
-										toastSuccess('Pipedrive disconnected', 'You can reconnect from this page.');
-									} else if (result.type === 'failure') {
-										toastError('Disconnect Pipedrive', (result.data as { message?: string })?.message);
-									}
-								}} class="inline">
-									<AlertDialog.Root bind:open={disconnectPipedriveOpen}>
-										<AlertDialog.Trigger>
-											<Button variant="ghost" size="sm">Disconnect</Button>
-										</AlertDialog.Trigger>
-										<AlertDialog.Content>
-											<AlertDialog.Header>
-												<AlertDialog.Title>Disconnect {selected.name}</AlertDialog.Title>
-												<AlertDialog.Description>
-													Contacts will no longer sync from {selected.name}. You can reconnect at any time.
-												</AlertDialog.Description>
-											</AlertDialog.Header>
-											<AlertDialog.Footer>
-												<AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
-												<AlertDialog.Action onclick={submitPipedriveDisconnect}>Disconnect</AlertDialog.Action>
-											</AlertDialog.Footer>
-										</AlertDialog.Content>
-									</AlertDialog.Root>
-								</form>
-							{/if}
-						</div>
-						{/if}
-					</div>
-				{:else}
-					<!-- CRM connect form: labels above inputs, button bottom left -->
-					{#if selected.id === 'hubspot'}
-						<form method="POST" action="?/connectHubSpot" use:enhance={() => async ({ result }) => {
-							toastFromActionResult('Connect HubSpot', result, 'HubSpot connected. Sync contacts to see them on the dashboard.');
-						}} class="flex flex-col gap-4">
-							<div class="space-y-4">
-								<div class="space-y-2">
-									<Label for="hubspot-apiKey">Private App token</Label>
-									<Input
-										id="hubspot-apiKey"
-										name="apiKey"
-										type="password"
-										placeholder="pat-na1-..."
-										autocomplete="off"
-										class="font-mono text-sm"
-									/>
-									<p class="text-xs text-muted-foreground">HubSpot → Settings → Integrations → Private Apps</p>
-								</div>
-							</div>
-							<div class="mt-auto pt-2">
-								<Button type="submit">Connect HubSpot</Button>
-							</div>
-						</form>
-					{:else if selected.id === 'gohighlevel'}
-						<form method="POST" action="?/connectGoHighLevel" use:enhance={() => async ({ result }) => {
-							toastFromActionResult('Connect GoHighLevel', result, 'GoHighLevel connected. Sync contacts to see them on the dashboard.');
-						}} class="flex flex-col gap-4">
-							<div class="space-y-4">
-								<div class="space-y-2">
-									<Label for="ghl-apiKey">API token</Label>
-									<Input
-										id="ghl-apiKey"
-										name="apiKey"
-										type="password"
-										placeholder="Your token"
-										autocomplete="off"
-										class="font-mono text-sm"
-									/>
-									<p class="text-xs text-muted-foreground">Sub-Account or Location token with contacts.readonly</p>
-								</div>
-							</div>
-							<div class="mt-auto pt-2">
-								<Button type="submit">Connect GoHighLevel</Button>
-							</div>
-						</form>
-					{:else}
-						<form method="POST" action="?/connectPipedrive" use:enhance={() => async ({ result }) => {
-							toastFromActionResult('Connect Pipedrive', result, 'Pipedrive connected. Sync contacts to see them on the dashboard.');
-						}} class="flex flex-col gap-4">
-							<div class="space-y-4">
-								<div class="space-y-2">
-									<Label for="pipedrive-domain">Company domain</Label>
-									<Input
-										id="pipedrive-domain"
-										name="domain"
-										type="text"
-										placeholder="mycompany"
-										autocomplete="off"
-										class="font-mono text-sm"
-									/>
-								</div>
-								<div class="space-y-2">
-									<Label for="pipedrive-apiKey">API token</Label>
-									<Input
-										id="pipedrive-apiKey"
-										name="apiKey"
-										type="password"
-										placeholder="••••••••"
-										autocomplete="off"
-										class="font-mono text-sm"
-									/>
-									<p class="text-xs text-muted-foreground">Pipedrive → Settings → Personal preferences → API</p>
-								</div>
-							</div>
-							<div class="mt-auto pt-2">
-								<Button type="submit">Connect Pipedrive</Button>
 							</div>
 						</form>
 					{/if}

--- a/apps/lead-rosetta/src/routes/dashboard/prospects/+page.server.ts
+++ b/apps/lead-rosetta/src/routes/dashboard/prospects/+page.server.ts
@@ -74,6 +74,14 @@ import {
 } from '$lib/server/send';
 import { generateEmailCopy } from '$lib/server/generateEmailCopy';
 import { getTemplates } from '$lib/server/templates';
+import { PROSPECT_STATUS, isProspectQueuedStatus } from '$lib/prospectStatus';
+import { importProspectsFromCsv } from '$lib/server/csvImport';
+import {
+	runPullGbpDental,
+	getGbpDentalDailyStats,
+	getGbpDentalPullLock,
+	isPlacesConfiguredForGbp
+} from '$lib/server/pullGbpDental';
 
 export const load: PageServerLoad = async ({ cookies }) => {
 	const cookie = cookies.get(getSessionCookieName());
@@ -103,6 +111,10 @@ export const load: PageServerLoad = async ({ cookies }) => {
 		getInsightsJobsForUser(user.id)
 	]);
 	const sendConfigured = await getSendConfigured(user.id);
+	const { todayCount: gbpDentalTodayCount, dailyCap: gbpDentalDailyCap } =
+		await getGbpDentalDailyStats(user.id);
+	const gbpDentalPullLock = await getGbpDentalPullLock(user.id);
+	const placesApiConfigured = isPlacesConfiguredForGbp();
 	return {
 		prospects,
 		prospectsError: 'error' in result ? result.error : undefined,
@@ -116,11 +128,23 @@ export const load: PageServerLoad = async ({ cookies }) => {
 		demoJobsByProspectId,
 		gbpJobsByProspectId,
 		insightsJobsByProspectId,
-		sendConfigured
+		sendConfigured,
+		gbpDentalTodayCount,
+		gbpDentalDailyCap,
+		gbpDentalPullLock,
+		placesApiConfigured
 	};
 };
 
 export const actions: Actions = {
+	pullGbpDental: async ({ cookies }) => {
+		const cookie = cookies.get(getSessionCookieName());
+		const user = await getSessionFromCookie(cookie);
+		if (!user) return fail(401, { message: 'Sign in required' });
+		const result = await runPullGbpDental(user.id);
+		if (!result.ok) return fail(400, { message: result.message });
+		return { success: true, message: result.message, added: result.added };
+	},
 	/** Enqueue a demo creation job; processing runs in background via API. */
 	enqueueDemo: async ({ request, cookies }) => {
 		const cookie = cookies.get(getSessionCookieName());
@@ -168,7 +192,7 @@ export const actions: Actions = {
 		if (!result) {
 			return fail(503, { message: 'Could not enqueue job. Is Supabase configured?' });
 		}
-		await updateProspectStatus(prospectId, 'In queue');
+		await updateProspectStatus(prospectId, PROSPECT_STATUS.DEMO_QUEUED);
 		return {
 			queued: true,
 			jobId: result.jobId,
@@ -208,7 +232,7 @@ export const actions: Actions = {
 		if (needsPullData) {
 			const result = await enqueueInsightsJob(user.id, prospectId);
 			if (!result) return fail(503, { message: 'Could not enqueue. Try again.' });
-			await updateProspectStatus(prospectId, 'In queue');
+			await updateProspectStatus(prospectId, PROSPECT_STATUS.GBP_QUEUED);
 			return {
 				success: true,
 				step: 'insights',
@@ -232,7 +256,7 @@ export const actions: Actions = {
 			}
 			const result = await enqueueDemoJob(user.id, prospectId);
 			if (!result) return fail(503, { message: 'Could not enqueue demo job. Try again.' });
-			await updateProspectStatus(prospectId, 'In queue');
+			await updateProspectStatus(prospectId, PROSPECT_STATUS.DEMO_QUEUED);
 			return {
 				success: true,
 				step: 'demo',
@@ -323,7 +347,7 @@ export const actions: Actions = {
 		(scrapedData as Record<string, unknown>).demoSource = 'claude';
 		const origin = getOriginForOutgoingLinks(url.origin);
 		const demoUrl = `${origin}/demo/${prospectId}`;
-		const result = await updateProspectDemoLink(prospectId, demoUrl, 'Demo Created');
+		const result = await updateProspectDemoLink(prospectId, demoUrl, PROSPECT_STATUS.REVIEW);
 		if (!result.ok) {
 			return fail(502, { message: result.error ?? 'Failed to update prospect' });
 		}
@@ -463,7 +487,7 @@ export const actions: Actions = {
 				continue;
 			}
 			if (result.created) queued++;
-			await updateProspectStatus(prospectId, 'In queue');
+			await updateProspectStatus(prospectId, PROSPECT_STATUS.DEMO_QUEUED);
 		}
 		if (queued === 0 && errors.length > 0) {
 			return fail(502, { message: errors.slice(0, 3).join('; ') });
@@ -623,7 +647,7 @@ export const actions: Actions = {
 			const result = await enqueueGbpJob(user.id, prospectId);
 			if (result) {
 				if (result.created) queued++;
-				await updateProspectStatus(prospectId, 'In queue');
+				await updateProspectStatus(prospectId, PROSPECT_STATUS.GBP_QUEUED);
 			} else {
 				enqueueFailed++;
 			}
@@ -645,7 +669,7 @@ export const actions: Actions = {
 			const result = await enqueueInsightsJob(user.id, prospectId);
 			if (result) {
 				if (result.created) queued++;
-				await updateProspectStatus(prospectId, 'In queue');
+				await updateProspectStatus(prospectId, PROSPECT_STATUS.GBP_QUEUED);
 			}
 		}
 		return { success: true, queued, total: prospectIds.length };
@@ -727,7 +751,7 @@ export const actions: Actions = {
 			const result = await enqueueInsightsJob(user.id, prospectId);
 			if (result) {
 				if (result.created) pullDataQueued++;
-				await updateProspectStatus(prospectId, 'In queue');
+				await updateProspectStatus(prospectId, PROSPECT_STATUS.GBP_QUEUED);
 			} else {
 				pullDataEnqueueFailed++;
 			}
@@ -754,7 +778,7 @@ export const actions: Actions = {
 				continue;
 			}
 			if (result.created) demoQueued++;
-			await updateProspectStatus(prospectId, 'In queue');
+			await updateProspectStatus(prospectId, PROSPECT_STATUS.DEMO_QUEUED);
 		}
 
 		// Restore (unflag)
@@ -772,8 +796,8 @@ export const actions: Actions = {
 		};
 	},
 	/**
-	 * Clear "In queue" status for prospects that have no active job (demo, pull-data/insights, or legacy GBP).
-	 * Use when prospects appear stuck in queue (e.g. cron not running or jobs already finished).
+	 * Clear queued status for prospects that have no active job (demo, GBP, or insights).
+	 * Use when prospects appear stuck (e.g. cron not running or jobs already finished).
 	 */
 	clearStuckQueueStatus: async ({ cookies }) => {
 		const cookie = cookies.get(getSessionCookieName());
@@ -788,16 +812,47 @@ export const actions: Actions = {
 		]);
 		let cleared = 0;
 		for (const p of prospects) {
-			if ((p.status ?? '').trim() !== 'In queue') continue;
-			const hasDemoJob =
-				demoJobsByProspectId[p.id]?.status === 'pending' || demoJobsByProspectId[p.id]?.status === 'creating';
-			const hasGbpJob = gbpJobsByProspectId[p.id]?.status === 'pending';
-			const hasInsightsJob = insightsJobsByProspectId[p.id]?.status === 'pending';
+			if (!isProspectQueuedStatus(p.status)) continue;
+			const dj = demoJobsByProspectId[p.id];
+			const hasDemoJob = dj && (dj.status === 'pending' || dj.status === 'creating');
+			const hasGbpJob = Boolean(gbpJobsByProspectId[p.id]);
+			const hasInsightsJob = Boolean(insightsJobsByProspectId[p.id]);
 			if (!hasDemoJob && !hasGbpJob && !hasInsightsJob) {
-				await updateProspectStatus(p.id, 'Prospect');
+				await updateProspectStatus(p.id, PROSPECT_STATUS.NEW);
 				cleared++;
 			}
 		}
 		return { success: true, cleared };
+	},
+	/** Upload CSV: header row with company + email columns; optional website, phone, industry. Insert-only (skips existing). */
+	importCsv: async ({ request, cookies }) => {
+		const cookie = cookies.get(getSessionCookieName());
+		const user = await getSessionFromCookie(cookie);
+		if (!user) return fail(401, { message: 'Sign in required' });
+		const formData = await request.formData();
+		const file = formData.get('csvFile');
+		if (!file || !(file instanceof File)) {
+			return fail(400, { message: 'Choose a CSV file.' });
+		}
+		if (file.size > 2 * 1024 * 1024) {
+			return fail(400, { message: 'File too large (max 2 MB).' });
+		}
+		let text: string;
+		try {
+			text = await file.text();
+		} catch {
+			return fail(400, { message: 'Could not read file.' });
+		}
+		const result = await importProspectsFromCsv(user.id, text);
+		if (result.errors.length > 0 && result.inserted === 0 && result.skipped === 0 && result.failed === 0) {
+			return fail(400, { message: result.errors[0] ?? 'Import failed.' });
+		}
+		return {
+			success: true,
+			inserted: result.inserted,
+			skipped: result.skipped,
+			failed: result.failed,
+			errors: result.errors.length > 0 ? result.errors : undefined
+		};
 	}
 };

--- a/apps/lead-rosetta/src/routes/dashboard/prospects/+page.svelte
+++ b/apps/lead-rosetta/src/routes/dashboard/prospects/+page.svelte
@@ -2,17 +2,11 @@
 	import { applyAction, enhance } from '$app/forms';
 	import { invalidateAll, invalidate, goto } from '$app/navigation';
 	import { page } from '$app/stores';
-	import {
-		getNextStep,
-		getSimplifiedStatus,
-		NEXT_STEP_FILTER_OPTIONS,
-		getNextStepFilterLabel,
-		prospectMatchesNextStepFilter,
-		type NextStepFilterValue
-	} from '$lib/nextStep';
+	import { getNextStep, getSimplifiedStatus } from '$lib/nextStep';
 	import type { PageData } from './$types';
 	// Prospects page: full CRM table; no overview
 	import type { Prospect } from '$lib/server/prospects';
+	import { isProspectQueuedStatus } from '$lib/prospectStatus';
 
 	/** Prospect plus job/tracking status for table row so status column reacts to load updates. */
 	type ProspectRow = Prospect & {
@@ -23,7 +17,7 @@
 		/** True when scraped/GBP data exists; required for "Create demo" next step. */
 		hasGbpData?: boolean;
 	};
-	import { X, ExternalLink, Mail, MessageSquare, Copy, Link2, Send, Eye, Globe, Phone, MapPin, Star, ListChecks, Briefcase, LoaderCircle, ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight } from 'lucide-svelte';
+	import { X, ExternalLink, Mail, MessageSquare, Copy, Link2, Send, Eye, Globe, Phone, MapPin, Star, ListChecks, Briefcase, LoaderCircle, ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight, Upload } from 'lucide-svelte';
 	import SearchIcon from '@lucide/svelte/icons/search';
 	import ChevronDownIcon from '@lucide/svelte/icons/chevron-down';
 	import {
@@ -59,6 +53,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
 	import * as AlertDialog from '$lib/components/ui/alert-dialog';
+	import * as Dialog from '$lib/components/ui/dialog';
 	import * as Drawer from '$lib/components/ui/drawer';
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
 	import * as Select from '$lib/components/ui/select';
@@ -84,6 +79,15 @@ import { clientError } from '$lib/log';
 	);
 	const demoUsageLabel = $derived(
 		demoLimit === null ? 'Unlimited demos' : `${demoCountThisMonth} / ${demoLimit} demos this month`
+	);
+	const gbpDentalTodayCount = $derived(data.gbpDentalTodayCount ?? 0);
+	const gbpDentalDailyCap = $derived(data.gbpDentalDailyCap ?? 25);
+	const placesApiConfigured = $derived(data.placesApiConfigured ?? false);
+	const gbpDentalPullLock = $derived(
+		data.gbpDentalPullLock ?? { locked: false, remainingSeconds: 0, lockMinutes: 15 }
+	);
+	const gbpDentalLockMinutesRemaining = $derived(
+		Math.ceil((gbpDentalPullLock.remainingSeconds ?? 0) / 60)
 	);
 	const trackingCounts = $derived.by(() => {
 		const map = data.demoTrackingByProspectId ?? {};
@@ -153,10 +157,8 @@ import { clientError } from '$lib/log';
 			return s === 'opened' || s === 'clicked';
 		})
 	);
-	/** Count of prospects with status "In queue" (may be stuck if no active job). */
-	const prospectsInQueueCount = $derived(
-		prospects.filter((p) => (p.status ?? '').trim() === 'In queue').length
-	);
+	/** Count of prospects in a queued automation status (may be stuck if no active job). */
+	const prospectsInQueueCount = $derived(prospects.filter((p) => isProspectQueuedStatus(p.status)).length);
 
 	let generatingDemo = $state(false);
 	type ScrapedSummary = {
@@ -226,28 +228,6 @@ import { clientError } from '$lib/log';
 		httpCallLogs = [logEntry, ...httpCallLogs].slice(0, HTTP_CALL_LOGS_MAX);
 	}
 
-	/** Sort key for Next step column (order matches priority). */
-	function nextStepSortKey(p: ProspectRow): string {
-		const step = getNextStep(p, {
-			optimisticGbpIds: optimisticGbpProspectIds,
-			optimisticInsightsIds: optimisticInsightsProspectIds
-		});
-		const order: Record<NextStepFilterValue, string> = {
-			'': '12',
-			flagged: '00',
-			pull_data: '01',
-			create_demo: '02',
-			retry_demo: '03',
-			draft: '04',
-			approved: '05',
-			sent: '06',
-			engaged: '07',
-			replied: '08',
-			other: '11'
-		};
-		return `${order[step.filterValue] ?? '08'}_${step.label.toLowerCase().replace(/\s+/g, '_')}`;
-	}
-
 	/** True when the row is in a processing state (GBP, Insights, or demo creation). Rows with a demo or with a failed demo are selectable so they can be retried after running qualifier. */
 	function isRowProcessing(p: ProspectRow): boolean {
 		if ((p.demoLink ?? '').trim()) return false; // Already has demo -> selectable
@@ -258,7 +238,7 @@ import { clientError } from '$lib/log';
 		if (p.insightsJob) return true;
 		if (job?.status === 'pending' || job?.status === 'creating') return true;
 		// Persisted status so we treat as processing after refresh when job maps are empty
-		return (p.status ?? '').trim() === 'In queue';
+		return isProspectQueuedStatus(p.status);
 	}
 
 	/** Build a short user-facing alert for demo job failure: "Error - Description." */
@@ -312,19 +292,12 @@ import { clientError } from '$lib/log';
 	});
 
 	let filterQuery = $state('');
-	let nextStepFilter = $state<NextStepFilterValue>('');
-	const nextStepFilterLabel = $derived(getNextStepFilterLabel(nextStepFilter));
 
-	const hasActiveFilters = $derived(
-		filterQuery.trim() !== '' || nextStepFilter !== ''
-	);
-	const activeFilterCount = $derived(
-		(filterQuery.trim() ? 1 : 0) + (nextStepFilter ? 1 : 0)
-	);
+	const hasActiveFilters = $derived(filterQuery.trim() !== '');
+	const activeFilterCount = $derived(filterQuery.trim() ? 1 : 0);
 
 	function clearFilters() {
 		filterQuery = '';
-		nextStepFilter = '';
 	}
 
 	const filteredProspects = $derived.by((): ProspectRow[] => {
@@ -333,17 +306,17 @@ import { clientError } from '$lib/log';
 		const nextStepOpts = { optimisticGbpIds: optimisticGbpProspectIds, optimisticInsightsIds: optimisticInsightsProspectIds };
 		if (q) {
 			list = list.filter((p) => {
-				const nextStepLabel = getNextStep(p, nextStepOpts).label.toLowerCase();
+				const statusLabel = getSimplifiedStatus(p, {
+					...nextStepOpts,
+					hasGbpData: p.hasGbpData
+				}).label.toLowerCase();
 				return (
 					(p.companyName ?? '').toLowerCase().includes(q) ||
 					(p.email ?? '').toLowerCase().includes(q) ||
 					(p.website ?? '').toLowerCase().includes(q) ||
-					nextStepLabel.includes(q)
+					statusLabel.includes(q)
 				);
 			});
-		}
-		if (nextStepFilter !== '') {
-			list = list.filter((p) => prospectMatchesNextStepFilter(p, nextStepFilter, nextStepOpts));
 		}
 		return list;
 	});
@@ -371,6 +344,9 @@ import { clientError } from '$lib/log';
 	let sendDemosDialogOpen = $state(false);
 	let sendDemosForm: HTMLFormElement | null = $state(null);
 	let sendDemosSubmitting = $state(false);
+	let importCsvOpen = $state(false);
+	let importCsvSubmitting = $state(false);
+	let pullGbpDentalSubmitting = $state(false);
 	/** Prospect IDs we've just submitted for GBP/Insights so status updates immediately before server responds. */
 	let optimisticGbpProspectIds = $state<Set<string>>(new Set());
 	let optimisticInsightsProspectIds = $state<Set<string>>(new Set());
@@ -694,10 +670,10 @@ import { clientError } from '$lib/log';
 	$effect(() => {
 		const jobs = data.demoJobsByProspectId ?? {};
 		const hasPending = Object.values(jobs).some((j) => j.status === 'pending' || j.status === 'creating');
-		// Also poll when some prospects have no demo and "In queue" (demo may have completed or failed; refresh will update state)
+		// Also poll when some prospects have no demo and queued status (demo may have completed or failed; refresh will update state)
 		const prospects = data.prospects ?? [];
 		const inQueueNoDemo = prospects.some(
-			(p: Prospect) => !(p.demoLink ?? '').trim() && (p.status ?? '').trim() === 'In queue'
+			(p: Prospect) => !(p.demoLink ?? '').trim() && isProspectQueuedStatus(p.status)
 		);
 		if ((hasPending || inQueueNoDemo) && !demoJobPollingActive) startDemoJobPolling();
 	});
@@ -710,10 +686,10 @@ import { clientError } from '$lib/log';
 	$effect(() => {
 		const insightsJobs = data.insightsJobsByProspectId ?? {};
 		const hasInsightsJobs = Object.keys(insightsJobs).length > 0;
-		// Also poll when some prospects have no demo and "In queue" (insights may have completed; refresh will update state)
+		// Also poll when some prospects have no demo and queued status (insights may have completed; refresh will update state)
 		const prospects = data.prospects ?? [];
 		const inQueueNoDemo = prospects.some(
-			(p: Prospect) => !(p.demoLink ?? '').trim() && (p.status ?? '').trim() === 'In queue'
+			(p: Prospect) => !(p.demoLink ?? '').trim() && isProspectQueuedStatus(p.status)
 		);
 		if ((hasInsightsJobs || inQueueNoDemo) && !insightsJobPollingActive) startInsightsJobPolling();
 	});
@@ -871,11 +847,18 @@ import { clientError } from '$lib/log';
 			},
 			cell: ({ row }) => {
 				const p = row.original;
+				const scraped = data.scrapedDataByProspectId?.[p.id] as Record<string, unknown> | undefined;
+				const audit = auditFromScrapedData(scraped ?? null);
+				const hasGbpData = audit ? hasUsableInsight(audit) : false;
 				const status = getSimplifiedStatus(p, {
 					optimisticGbpIds: optimisticGbpProspectIds,
 					optimisticInsightsIds: optimisticInsightsProspectIds,
-					hasGbpData: p.hasGbpData
+					hasGbpData
 				});
+				const statusSpinner =
+					status.label === 'Processing GBP' ||
+					status.label === 'Processing Demo' ||
+					status.label === 'Processing…';
 				// Map to distinct badge styles: success=primary, warning=secondary, destructive=red, muted=outline, default=secondary
 				const badgeVariant =
 					status.variant === 'success'
@@ -889,39 +872,8 @@ import { clientError } from '$lib/log';
 									: 'secondary';
 				return renderComponent(DataTableStatusBadge, {
 					label: status.label,
-					variant: badgeVariant
-				});
-			}
-		},
-		{
-			id: 'nextStep',
-			accessorFn: (row) => nextStepSortKey(row as ProspectRow),
-			header: ({ column }) =>
-				renderComponent(DataTableSortHeader, { column, label: 'Next step' }),
-			meta: { label: 'Next step' },
-			cell: ({ row }) => {
-				const p = row.original;
-				const step = getNextStep(p, {
-					optimisticGbpIds: optimisticGbpProspectIds,
-					optimisticInsightsIds: optimisticInsightsProspectIds
-				});
-				const showSpinner =
-					step.label === 'Wait (GBP)' || step.label === 'Wait (Insights)' || step.label === 'Creating demo…';
-				// Map to distinct badge styles: success=primary, warning=secondary, destructive=red, muted=outline, default=secondary
-				const badgeVariant =
-					step.variant === 'success'
-						? 'default'
-						: step.variant === 'warning'
-							? 'secondary'
-							: step.variant === 'destructive'
-								? 'destructive'
-								: step.variant === 'muted'
-									? 'outline'
-									: 'secondary';
-				return renderComponent(DataTableStatusBadge, {
-					label: step.label,
 					variant: badgeVariant,
-					showSpinner
+					showSpinner: statusSpinner
 				});
 			}
 		},
@@ -955,6 +907,14 @@ import { clientError } from '$lib/log';
 					onProcessNextStep: handleProcessNextStep,
 					hasDemoLink: !!(p.demoLink ?? '').trim(),
 					demoJobStatus: demoStatus,
+					trackingStatus: p.tracking?.status as
+						| 'draft'
+						| 'approved'
+						| 'sent'
+						| 'opened'
+						| 'clicked'
+						| 'replied'
+						| undefined,
 					showDelete: !p.flagged,
 					showRestore: !!p.flagged,
 					onRegenerateQueued: () => startDemoJobPolling(),
@@ -1103,9 +1063,109 @@ import { clientError } from '$lib/log';
 		<Card.Header class="space-y-1 pb-6">
 			<Card.Title class="text-2xl font-semibold tracking-tight">Welcome back!</Card.Title>
 			<Card.Description class="text-muted-foreground">
-				Here's a list of your prospects. Search, filter by next step, and manage demos from the table.
+				Here's a list of your prospects. Search and manage demos from the table.
 			</Card.Description>
 		</Card.Header>
+		<Dialog.Root bind:open={importCsvOpen}>
+			<Dialog.Content class="sm:max-w-md">
+				<Dialog.Header>
+					<Dialog.Title>Import prospects from CSV</Dialog.Title>
+					<Dialog.Description>
+						Include a header row with <strong>company</strong> (or name) and <strong>email</strong>. Optional:
+						website, phone, industry. Up to 500 rows per file. Rows already in your list (same
+						company and email) are skipped.
+					</Dialog.Description>
+				</Dialog.Header>
+				<form
+					method="POST"
+					action="?/importCsv"
+					enctype="multipart/form-data"
+					use:enhance={() => {
+						importCsvSubmitting = true;
+						return async ({ result }) => {
+							importCsvSubmitting = false;
+							if (
+								result.type === 'success' &&
+								result.data &&
+								typeof result.data === 'object' &&
+								'success' in result.data &&
+								(result.data as { success?: boolean }).success
+							) {
+								const d = result.data as {
+									inserted?: number;
+									skipped?: number;
+									failed?: number;
+									errors?: string[];
+								};
+								const parts = [
+									`Added ${d.inserted ?? 0}`,
+									`skipped ${d.skipped ?? 0}`
+								];
+								if ((d.failed ?? 0) > 0) parts.push(`failed ${d.failed}`);
+								toastSuccess('Import CSV', parts.join(', ') + '.');
+								if (d.errors?.length) {
+									toastInfo('Import', d.errors.slice(0, 5).join(' '));
+								}
+								importCsvOpen = false;
+								await invalidateAll();
+							} else if (result.type === 'failure' && result.data?.message) {
+								toastError('Import CSV', (result.data as { message?: string }).message);
+							}
+						};
+					}}
+					class="space-y-4"
+				>
+					<div class="space-y-2">
+						<Label for="lr-import-csv">CSV file</Label>
+						<Input
+							id="lr-import-csv"
+							name="csvFile"
+							type="file"
+							accept=".csv,text/csv"
+							required
+							class="cursor-pointer"
+						/>
+					</div>
+					<Dialog.Footer class="gap-2 sm:gap-2">
+						<Button
+							type="button"
+							variant="outline"
+							disabled={importCsvSubmitting}
+							onclick={() => (importCsvOpen = false)}
+						>
+							Cancel
+						</Button>
+						<Button type="submit" disabled={importCsvSubmitting}>
+							{#if importCsvSubmitting}
+								<LoaderCircle class="mr-2 size-4 animate-spin" aria-hidden="true" />
+							{/if}
+							{importCsvSubmitting ? 'Importing…' : 'Import'}
+						</Button>
+					</Dialog.Footer>
+				</form>
+			</Dialog.Content>
+		</Dialog.Root>
+		{#if prospects.length === 0}
+			<div class="mx-4 mb-4 sm:mx-6">
+				<div
+					class="flex flex-col gap-4 rounded-lg border border-border/50 bg-muted/30 px-4 py-4 sm:flex-row sm:items-center sm:justify-between sm:gap-6"
+				>
+					<p class="text-sm text-muted-foreground">
+						No prospects yet. Import a CSV to add rows, or connect an integration and sync.
+					</p>
+					<Button
+						type="button"
+						variant="outline"
+						size="sm"
+						class="h-9 shrink-0 bg-background"
+						onclick={() => (importCsvOpen = true)}
+					>
+						<Upload class="mr-2 size-4" aria-hidden="true" />
+						Import CSV
+					</Button>
+				</div>
+			</div>
+		{/if}
 		{#if prospects.length > 0}
 			<div class="mx-4 mb-4 sm:mx-6">
 				<div
@@ -1182,7 +1242,7 @@ import { clientError } from '$lib/log';
 						<Input
 							id="lr-dash-filter"
 							type="search"
-							placeholder="Search by company, email, website..."
+							placeholder="Search by company, email, website, status…"
 							bind:value={filterQuery}
 							aria-label="Search prospects"
 							autocomplete="off"
@@ -1209,25 +1269,8 @@ import { clientError } from '$lib/log';
 						</div>
 					</div>
 
-					<!-- Next step filter -->
-					<div class="flex flex-wrap items-center gap-3 sm:gap-4">
-						<Select.Root type="single" bind:value={nextStepFilter}>
-							<Select.Trigger
-								id="lr-dash-next-step"
-								class="min-w-[11rem] h-9 bg-background font-normal border-border/50"
-								aria-label="Filter by next step"
-							>
-								<span class="text-muted-foreground mr-1.5 text-xs">Next step:</span>
-								{nextStepFilterLabel}
-							</Select.Trigger>
-							<Select.Content>
-								{#each NEXT_STEP_FILTER_OPTIONS as opt (opt.value)}
-									<Select.Item value={opt.value}>{opt.label}</Select.Item>
-								{/each}
-							</Select.Content>
-						</Select.Root>
-
-						{#if prospectsInQueueCount > 0}
+					{#if prospectsInQueueCount > 0}
+						<div class="flex flex-wrap items-center gap-3 sm:gap-4">
 							<form
 								method="POST"
 								action="?/clearStuckQueueStatus"
@@ -1249,7 +1292,7 @@ import { clientError } from '$lib/log';
 											} else {
 												toastInfo(
 													'Queue status',
-													'No stuck prospects found. All Processing… have an active job.'
+													'No stuck prospects found. All queue rows have an active job.'
 												);
 												await invalidateAll();
 											}
@@ -1266,19 +1309,71 @@ import { clientError } from '$lib/log';
 									size="sm"
 									class="h-9"
 									disabled={clearStuckSubmitting}
-									title="Clear Processing… status for prospects with no active job (demo, GBP, or insights)"
+									title="Clear stuck gbp queued / demo queued when no active job"
 								>
 									{#if clearStuckSubmitting}
 										<LoaderCircle class="mr-1.5 size-4 animate-spin" aria-hidden="true" />
 									{/if}
-									{clearStuckSubmitting ? 'Clearing…' : 'Clear stuck Processing…'}
+									{clearStuckSubmitting ? 'Clearing…' : 'Clear stuck queue'}
 								</Button>
 							</form>
-						{/if}
-					</div>
+						</div>
+					{/if}
 
-					<!-- Clear filters + Columns -->
+					<!-- Clear filters + Import + Columns -->
 					<div class="flex shrink-0 items-center gap-2 border-t border-border/50 pt-4 sm:ms-auto sm:border-0 sm:pt-0">
+						<form
+							method="POST"
+							action="?/pullGbpDental"
+							use:enhance={() => {
+								pullGbpDentalSubmitting = true;
+								return async ({ result }) => {
+									pullGbpDentalSubmitting = false;
+									if (result.type === 'success' && result.data && typeof result.data === 'object') {
+										const d = result.data as { message?: string; added?: number };
+										toastSuccess('Lead discovery', d.message ?? `Added ${d.added ?? 0} prospect(s).`);
+										await invalidateAll();
+									} else if (result.type === 'failure' && result.data?.message) {
+										toastError('Lead discovery', (result.data as { message?: string }).message);
+										await applyAction(result);
+									}
+								};
+							}}
+						>
+							<Button
+								type="submit"
+								variant="outline"
+								size="sm"
+								class="h-9 bg-background"
+								disabled={pullGbpDentalSubmitting || !placesApiConfigured || gbpDentalTodayCount >= gbpDentalDailyCap || gbpDentalPullLock.locked}
+								title={!placesApiConfigured
+									? 'Set GOOGLE_PLACES_API_KEY in .env'
+									: gbpDentalPullLock.locked
+										? `Locked for ${gbpDentalLockMinutesRemaining} more minute${gbpDentalLockMinutesRemaining === 1 ? '' : 's'}`
+										: `Today: ${gbpDentalTodayCount}/${gbpDentalDailyCap}`}
+							>
+								{#if pullGbpDentalSubmitting}
+									<LoaderCircle class="mr-2 size-4 animate-spin" aria-hidden="true" />
+								{:else}
+									<MapPin class="mr-2 size-4" aria-hidden="true" />
+								{/if}
+								{#if gbpDentalPullLock.locked}
+									Lead discovery locked
+								{:else}
+									Lead discovery (GBP)
+								{/if}
+							</Button>
+						</form>
+						<Button
+							type="button"
+							variant="outline"
+							size="sm"
+							class="h-9 bg-background"
+							onclick={() => (importCsvOpen = true)}
+						>
+							<Upload class="mr-2 size-4" aria-hidden="true" />
+							Import CSV
+						</Button>
 						{#if hasActiveFilters}
 							<Button
 								type="button"
@@ -1430,7 +1525,7 @@ import { clientError } from '$lib/log';
 										<input type="hidden" name="demoIds" value={JSON.stringify(partition.demo)} />
 										<input type="hidden" name="flaggedIds" value={JSON.stringify(partition.flagged)} />
 										<div class="flex flex-wrap items-center gap-2">
-											<span class="text-muted-foreground text-sm" title="Next step for each selected row">{nextStepSummary}</span>
+											<span class="text-muted-foreground text-sm" title="Queued action per selected row">{nextStepSummary}</span>
 											<Button type="submit" size="sm" disabled={bulkProcessNextStepSubmitting}>
 												{#if bulkProcessNextStepSubmitting}
 													<LoaderCircle class="mr-2 size-4 animate-spin" aria-hidden="true" />
@@ -1440,7 +1535,7 @@ import { clientError } from '$lib/log';
 										</div>
 									</form>
 								{:else}
-									<span class="text-muted-foreground text-sm">Selected rows have no queueable next step (e.g. Review &amp; send or already sent).</span>
+									<span class="text-muted-foreground text-sm">Selected rows have no queueable action (e.g. review &amp; send or already sent).</span>
 								{/if}
 							{/if}
 						</div>
@@ -1575,7 +1670,7 @@ import { clientError } from '$lib/log';
 							{#if createDemosSubmitting}
 								Usually 1–2 minutes per prospect. The list will update as each finishes.
 							{:else}
-								Demo pages will be generated for the selected prospects that don't have a demo yet. Each will be set to Draft. This usually takes 1–2 minutes per prospect; the list will update as each finishes.
+								Demo pages will be generated for the selected prospects that don't have a demo yet. Each moves to Review when ready. This usually takes 1–2 minutes per prospect; the list will update as each finishes.
 							{/if}
 						</AlertDialog.Description>
 					</AlertDialog.Header>
@@ -1818,9 +1913,7 @@ import { clientError } from '$lib/log';
 		</Card.Content>
 	</Card.Root>
 
-	{#if prospects.length === 0}
-		<p class="py-8 text-sm text-muted-foreground">No prospects yet. Connect an integration and sync, or add from your CRM.</p>
-	{:else if filteredProspects.length === 0}
+	{#if prospects.length > 0 && filteredProspects.length === 0}
 		<p class="py-8 text-sm text-muted-foreground">No prospects match your filter. Try a different search.</p>
 	{/if}
 </div>


### PR DESCRIPTION
## Summary
- Add `Lead discovery (GBP)` action directly to the Prospects page so users do not need to use Integrations for routine discovery.
- Enforce a server-side 15-minute lock between pulls, and surface lock state in both Prospects and Integrations.
- Update GBP dental pull behavior to include dental leads regardless of website presence.

## Scope guardrails
- Includes only lead-rosetta changes for GBP discovery/pull workflow.
- Excludes all `apps/landing` changes.

## Test plan
- [ ] Open Dashboard -> Prospects and run `Lead discovery (GBP)`.
- [ ] Re-run immediately and confirm lock message + disabled state for 15 minutes.
- [ ] Confirm Integrations view shows same lock state.
- [ ] Confirm discovered dental leads are not filtered by website presence.

Fixes #18