### PR TITLE
fix(lead-rosetta): align status pipeline and processing visibility

### DIFF
--- a/apps/lead-rosetta/src/routes/dashboard/+page.server.ts
+++ b/apps/lead-rosetta/src/routes/dashboard/+page.server.ts
@@ -50,14 +50,37 @@ export const load: PageServerLoad = async ({ cookies }) => {
 	}
 	const plan = await getPlanForUser(user);
 	const demoLimit = getDemoCreationLimit(plan);
-	const [demoCountThisMonth, gbpCountThisMonth, insightsCountThisMonth, placesCountThisMonth] =
+	const [demoCountThisMonth, gbpCountThisMonth, insightsCountThisMonth, placesCountThisMonth, prospectsResult] =
 		await Promise.all([
 			getDemoCountThisMonth(user.id),
 			getGbpCountThisMonth(user.id),
 			getInsightsCountThisMonth(user.id),
-			getPlacesCountThisMonth()
+			getPlacesCountThisMonth(),
+			listProspects(user.id)
 		]);
 	const placesMonthlyLimit = getPlacesMonthlyLimit();
+	const prospects = prospectsResult.prospects ?? [];
+	const statusOrder: Array<{ key: string; label: string }> = [
+		{ key: PROSPECT_STATUS.NEW, label: 'New' },
+		{ key: PROSPECT_STATUS.GBP_QUEUED, label: 'GBP Queued' },
+		{ key: PROSPECT_STATUS.DEMO_PENDING, label: 'Pending Demo' },
+		{ key: PROSPECT_STATUS.DEMO_QUEUED, label: 'Demo Queued' },
+		{ key: PROSPECT_STATUS.REVIEW, label: 'Review' },
+		{ key: PROSPECT_STATUS.READY_TO_SEND, label: 'Ready to Send' },
+		{ key: PROSPECT_STATUS.EMAIL_SENT, label: 'Demo Sent' },
+		{ key: PROSPECT_STATUS.DEMO_OPENED, label: 'Demo Opened' },
+		{ key: PROSPECT_STATUS.FOLLOW_UP, label: 'Follow-up' }
+	];
+	const statusCounts = new Map<string, number>();
+	for (const p of prospects) {
+		const key = (p.status ?? '').trim().toLowerCase();
+		if (!key) continue;
+		statusCounts.set(key, (statusCounts.get(key) ?? 0) + 1);
+	}
+	const statusChartData = statusOrder.map((s) => ({
+		status: s.label,
+		count: statusCounts.get(s.key.toLowerCase()) ?? 0
+	}));
 
 	return {
 		user,
@@ -67,7 +90,8 @@ export const load: PageServerLoad = async ({ cookies }) => {
 		gbpCountThisMonth,
 		insightsCountThisMonth,
 		placesCountThisMonth,
-		placesMonthlyLimit
+		placesMonthlyLimit,
+		statusChartData
 	};
 };
 

--- a/apps/lead-rosetta/src/routes/dashboard/+page.svelte
+++ b/apps/lead-rosetta/src/routes/dashboard/+page.svelte
@@ -29,6 +29,9 @@
 		{ metric: 'Demos', count: demoCount },
 		{ metric: 'Places API', count: placesCount }
 	]);
+	const prospectStatusChartData = $derived(
+		(data.statusChartData as Array<{ status: string; count: number }> | undefined) ?? []
+	);
 
 	const chartConfig = {
 		count: { label: 'This month', color: 'var(--primary)' }
@@ -91,6 +94,39 @@
 						{
 							key: 'count',
 							label: chartConfig.count.label,
+							color: chartConfig.count.color
+						}
+					]}
+					props={{
+						xAxis: { format: (d: string) => d },
+						yAxis: { format: (v: number) => String(v) }
+					}}
+				>
+					{#snippet tooltip()}
+						<Chart.Tooltip />
+					{/snippet}
+				</BarChart>
+			</Chart.Container>
+		</Card.Content>
+	</Card.Root>
+
+	<Card.Root>
+		<Card.Header class="pb-2">
+			<Card.Title class="text-base font-semibold">Prospect status pipeline</Card.Title>
+			<Card.Description class="text-sm">Current prospect counts by status</Card.Description>
+		</Card.Header>
+		<Card.Content class="px-2 pt-4 sm:px-6 sm:pt-6">
+			<Chart.Container config={chartConfig} class="min-h-[240px] w-full">
+				<BarChart
+					data={prospectStatusChartData}
+					xScale={scaleBand().padding(0.2)}
+					x="status"
+					axis="x"
+					seriesLayout="group"
+					series={[
+						{
+							key: 'count',
+							label: 'Prospects',
 							color: chartConfig.count.color
 						}
 					]}

--- a/apps/lead-rosetta/src/routes/dashboard/prospects/+page.svelte
+++ b/apps/lead-rosetta/src/routes/dashboard/prospects/+page.svelte
@@ -159,6 +159,19 @@ import { clientError } from '$lib/log';
 	);
 	/** Count of prospects in a queued automation status (may be stuck if no active job). */
 	const prospectsInQueueCount = $derived(prospects.filter((p) => isProspectQueuedStatus(p.status)).length);
+	const processingSummary = $derived.by(() => {
+		const gbpJobs = Object.values(data.gbpJobsByProspectId ?? {});
+		const insightsJobs = Object.values(data.insightsJobsByProspectId ?? {});
+		const demoJobs = Object.values(data.demoJobsByProspectId ?? {});
+		const gbpCount = gbpJobs.filter((j) => j.status === 'pending' || j.status === 'running').length;
+		const insightsCount = insightsJobs.filter((j) => j.status === 'pending' || j.status === 'running').length;
+		const demoCount = demoJobs.filter((j) => j.status === 'pending' || j.status === 'creating').length;
+		const parts: string[] = [];
+		if (gbpCount > 0) parts.push(`GBP ${gbpCount}`);
+		if (insightsCount > 0) parts.push(`Insights ${insightsCount}`);
+		if (demoCount > 0) parts.push(`Demo ${demoCount}`);
+		return parts.join(' · ');
+	});
 
 	let generatingDemo = $state(false);
 	type ScrapedSummary = {
@@ -1268,6 +1281,15 @@ import { clientError } from '$lib/log';
 							{/if}
 						</div>
 					</div>
+
+					{#if processingSummary}
+						<div class="flex items-center">
+							<Badge variant="outline" class="h-8 px-2 text-xs">
+								<LoaderCircle class="mr-1.5 size-3 animate-spin" aria-hidden="true" />
+								Now processing: {processingSummary}
+							</Badge>
+						</div>
+					{/if}
 
 					{#if prospectsInQueueCount > 0}
 						<div class="flex flex-wrap items-center gap-3 sm:gap-4">

--- a/apps/lead-rosetta/src/routes/dashboard/prospects/[id]/+page.svelte
+++ b/apps/lead-rosetta/src/routes/dashboard/prospects/[id]/+page.svelte
@@ -343,6 +343,7 @@
 	function startDemoJobPolling() {
 		if (demoJobPollingActive) return;
 		demoJobPollingActive = true;
+		toastInfo('Demo', 'Processing demo job…');
 		const maxAttempts = 50;
 		let attempts = 0;
 		const run = async () => {
@@ -463,6 +464,7 @@
 	function startGbpJobPolling() {
 		if (gbpJobPollingActive) return;
 		gbpJobPollingActive = true;
+		toastInfo('GBP', 'Processing GBP and insights…');
 		const prospectId = prospect.id;
 		const maxAttempts = 80;
 		let attempts = 0;
@@ -515,6 +517,7 @@
 	function startInsightsJobPolling() {
 		if (insightsJobPollingActive) return;
 		insightsJobPollingActive = true;
+		toastInfo('Insights', 'Processing insights job…');
 		const prospectId = prospect.id;
 		const maxAttempts = 80;
 		let attempts = 0;


### PR DESCRIPTION
## Summary
- align Lead Rosetta dashboard prospect status labels and lifecycle handling with current workflow expectations
- improve prospects table/operator feedback by showing a concise live "Now processing" summary instead of repeated looping toasts
- refine prospect detail interactions and processing notifications for active demo/GBP/insights job states

## Test plan
- [ ] run `npm run dev` in `apps/lead-rosetta`
- [ ] verify prospects table status labels across queued/running/review/ready/sent/opened cases
- [ ] verify "Now processing" badge updates when GBP/insights/demo jobs are pending/running
- [ ] verify prospect detail page processing toasts appear once per started poller and stop when queue empties
- [ ] verify no regressions for send/regenerate actions in prospects table and detail page

Closes #22