### PR TITLE
fix(lead-rosetta): harden AI agent prompt save path

### DIFF
--- a/apps/lead-rosetta/README.md
+++ b/apps/lead-rosetta/README.md
@@ -92,6 +92,8 @@ Core engines (Demo, Insights, GBP, Prospects, Send, Auth, CRM, Billing, Supabase
    - `supabase/migrations/20260303100000_consolidated_prospects_user_settings_crm_flagged.sql`
    - `supabase/migrations/20260303120000_prospects_add_address.sql`
    - `supabase/migrations/20260304120000_demo_jobs.sql`
+   - `supabase/migrations/20260310120000_agent_content_versions.sql`
+   - `supabase/migrations/20260313120000_agent_content_versions_add_email_gbp.sql`
 
    Copy each file's contents into the editor and run it.
 

--- a/apps/lead-rosetta/src/lib/server/agentContent.ts
+++ b/apps/lead-rosetta/src/lib/server/agentContent.ts
@@ -86,7 +86,24 @@ export async function saveAgentContent(
 		version: nextVersion
 	});
 
-	if (error) return { ok: false, error: error.message };
+	if (error) {
+		const lowerError = error.message.toLowerCase();
+		if (lowerError.includes('agent_content_versions_agent')) {
+			return {
+				ok: false,
+				error:
+					'Database migration is out of date for AI agent prompts. Run migration 20260313120000_agent_content_versions_add_email_gbp.sql.'
+			};
+		}
+		if (lowerError.includes('relation') && lowerError.includes('agent_content_versions')) {
+			return {
+				ok: false,
+				error:
+					'Missing database table for AI agent prompts. Run migration 20260310120000_agent_content_versions.sql.'
+			};
+		}
+		return { ok: false, error: error.message };
+	}
 	return { ok: true, version: nextVersion };
 }
 

--- a/apps/lead-rosetta/supabase/migrations/20260310120000_agent_content_versions.sql
+++ b/apps/lead-rosetta/supabase/migrations/20260310120000_agent_content_versions.sql
@@ -19,10 +19,22 @@ comment on column public.agent_content_versions.content_type is 'prompt | knowle
 comment on column public.agent_content_versions.key is 'E.g. tone_selection, system_instruction, audit, audit_modal_copy, tone_guidance, chat_kb, demo_kb';
 comment on column public.agent_content_versions.version is 'Incrementing version per (agent_id, content_type, key).';
 
-create index idx_agent_content_versions_latest
+create index if not exists idx_agent_content_versions_latest
   on public.agent_content_versions (agent_id, content_type, key, version desc);
 
 alter table public.agent_content_versions enable row level security;
 
-create policy "Service role full access to agent_content_versions"
-  on public.agent_content_versions for all using (true) with check (true);
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_policies
+    where schemaname = 'public'
+      and tablename = 'agent_content_versions'
+      and policyname = 'Service role full access to agent_content_versions'
+  ) then
+    create policy "Service role full access to agent_content_versions"
+      on public.agent_content_versions for all using (true) with check (true);
+  end if;
+end
+$$;


### PR DESCRIPTION
## Summary
- return actionable server errors when saving AI agent content fails due to missing or outdated Supabase migrations
- make `agent_content_versions` migration idempotent (`create index if not exists` + guarded policy creation)
- document agent content migrations in `apps/lead-rosetta/README.md` setup steps

## Test plan
- [x] run lints on edited files
- [x] verify commit only includes lead-rosetta prompt-save files
- [x] apply migrations in Supabase and confirm Dashboard -> AI Agents save succeeds

Fixes #24