### PR TITLE
chore: remove pitch-rosetta env aliases; use website-template

### DIFF
--- a/apps/cron-worker/README.md
+++ b/apps/cron-worker/README.md
@@ -60,7 +60,7 @@ The same `CRON_SECRET` used by the admin app must be set here so the app accepts
 npx wrangler dev --test-scheduled
 ```
 
-Then in another terminal, fire the single scheduled handler (runs all minute-modulo branches; at UTC minute 0 you get demo + GBP + insights + batch + pitch):
+Then in another terminal, fire the single scheduled handler (runs all minute-modulo branches; at UTC minute 0 you get demo + GBP + insights + batch + website-template health):
 
 ```bash
 curl "http://localhost:8787/__scheduled?cron=*%2F1+*+*+*+*"

--- a/apps/cron-worker/src/index.ts
+++ b/apps/cron-worker/src/index.ts
@@ -13,7 +13,6 @@ export interface Env {
 	CRON_SECRET: string;
 	CRON_TARGET_URL: string;
 	WEBSITE_TEMPLATE_URL?: string;
-	PITCH_ROSETTA_URL?: string;
 }
 
 async function callCron(url: string, secret: string): Promise<{ ok: boolean; status: number; text: string }> {
@@ -65,8 +64,8 @@ export default {
 
 		// Every 14 min: Website Template warm (minute 0, 14, 28, 42, 56 UTC)
 		if (minute % 14 === 0) {
-			const pitchBase = (env.WEBSITE_TEMPLATE_URL ?? env.PITCH_ROSETTA_URL ?? "https://website-template.ednsy.com").replace(/\/$/, "");
-			const r = await pingHealth(`${pitchBase}/api/health`);
+			const websiteTemplateBase = (env.WEBSITE_TEMPLATE_URL ?? "https://website-template.ednsy.com").replace(/\/$/, "");
+			const r = await pingHealth(`${websiteTemplateBase}/api/health`);
 			console.log(`[cron-worker] website-template: ${r.status} ${r.ok ? "ok" : r.text}`);
 		}
 	},

--- a/apps/cron-worker/wrangler.toml
+++ b/apps/cron-worker/wrangler.toml
@@ -11,6 +11,6 @@ WEBSITE_TEMPLATE_URL = "https://website-template-68wq.onrender.com"
 
 [triggers]
 # Single trigger to stay within Cloudflare Free "Cron Triggers per account" (5). Handler runs every minute and
-# dispatches GBP (*/2), insights (*/3), batch (*/5), pitch ping (*/14) by UTC minute — same as separate crons.
+# dispatches GBP (*/2), insights (*/3), batch (*/5), website-template health (*/14) by UTC minute — same as separate crons.
 # See: https://developers.cloudflare.com/workers/platform/limits/#account-plan-limits
 crons = ["*/1 * * * *"]

--- a/apps/website-template/generate.js
+++ b/apps/website-template/generate.js
@@ -47,7 +47,7 @@ const SUPABASE_STORAGE_PREFIX = "demo-html";
 const DEMOS_DIR = resolve(__dirname, "demos");
 const OUTPUT_DIR = resolve(__dirname, "output");
 
-const DEBUG = /^(1|true|yes|website-template|pitch-rosetta)$/i.test((process.env.DEBUG ?? "").trim());
+const DEBUG = /^(1|true|yes|website-template)$/i.test((process.env.DEBUG ?? "").trim());
 function debug(...args) {
   if (DEBUG) console.log("[website-template]", ...args);
 }

--- a/apps/website-template/server.js
+++ b/apps/website-template/server.js
@@ -34,7 +34,7 @@ if (BASE_URL && openApiSpec.servers?.length) {
   openApiSpec.servers = [{ url: BASE_URL.replace(/\/$/, ""), description: "API" }, ...openApiSpec.servers];
 }
 
-const DEBUG = /^(1|true|yes|website-template|pitch-rosetta)$/i.test((process.env.DEBUG ?? "").trim());
+const DEBUG = /^(1|true|yes|website-template)$/i.test((process.env.DEBUG ?? "").trim());
 
 function debug(...args) {
   if (DEBUG) console.log("[website-template]", ...args);
@@ -52,7 +52,7 @@ function log(level, ...args) {
 const PORT = parseInt(process.env.PORT ?? "3000", 10);
 const MAX_BODY_SIZE = "1mb";
 
-const API_KEY = (process.env.DEMO_GENERATOR_API_KEY ?? process.env.WEBSITE_TEMPLATE_API_KEY ?? process.env.PITCH_ROSETTA_API_KEY ?? "").trim();
+const API_KEY = (process.env.DEMO_GENERATOR_API_KEY ?? process.env.WEBSITE_TEMPLATE_API_KEY ?? "").trim();
 const ALLOWED_CALLBACK_ORIGINS = (process.env.ALLOWED_CALLBACK_ORIGINS ?? "")
   .split(",")
   .map((s) => s.trim().toLowerCase())

--- a/scripts/cron-mock.mjs
+++ b/scripts/cron-mock.mjs
@@ -2,8 +2,8 @@
 /**
  * Local mock for production cron: matches apps/cron-worker (single schedule, UTC minute branches).
  *
- * Each tick: demo every time; GBP / insights / batch / pitch when UTC minute matches the same
- * modulo rules as the Worker (2, 3, 5, 14). Pitch pings GET /api/health (no auth).
+ * Each tick: demo every time; GBP / insights / batch / website-template when UTC minute matches the same
+ * modulo rules as the Worker (2, 3, 5, 14). Website Template pings GET /api/health (no auth).
  *
  * Usage (from repo root or apps/admin):
  *   node scripts/cron-mock.mjs
@@ -49,7 +49,7 @@ if (!process.env.CRON_SECRET) loadEnvFromDir(process.cwd());
 const CRON_SECRET = (process.env.CRON_SECRET ?? '').trim();
 const BASE_URL = (process.env.BASE_URL ?? 'http://localhost:5173').replace(/\/$/, '');
 const TICK_MS = Math.max(10000, parseInt(process.env.CRON_INTERVAL_MS || '60000', 10));
-const PITCH_BASE = (process.env.WEBSITE_TEMPLATE_URL ?? process.env.PITCH_ROSETTA_URL ?? 'https://website-template.ednsy.com').replace(/\/$/, '');
+const WEBSITE_TEMPLATE_BASE = (process.env.WEBSITE_TEMPLATE_URL ?? 'https://website-template.ednsy.com').replace(/\/$/, '');
 
 if (!CRON_SECRET) {
 	console.error('Missing CRON_SECRET. Set it in apps/admin/.env or .env.local (e.g. CRON_SECRET=my-local-cron-secret-16chars)');
@@ -79,8 +79,8 @@ async function callCron(path, label) {
 	}
 }
 
-async function pingPitch() {
-	const url = `${PITCH_BASE}/api/health`;
+async function pingWebsiteTemplateHealth() {
+	const url = `${WEBSITE_TEMPLATE_BASE}/api/health`;
 	try {
 		const res = await fetch(url, { method: 'GET' });
 		const text = await res.text().catch(() => '');
@@ -111,7 +111,7 @@ function formatResult(r) {
 	return `[${time}] ${r.label}: queue ${qStr}`;
 }
 
-function formatPitch(r) {
+function formatWebsiteTemplateHealth(r) {
 	const time = new Date().toISOString();
 	if (r.ok) return `[${time}] website-template: ${r.status} ok`;
 	return `[${time}] website-template: ${r.status ?? ''} ${r.error ?? r.text ?? 'failed'}`;
@@ -136,13 +136,13 @@ async function tick() {
 		console.log(formatResult(r));
 	}
 	if (minute % 14 === 0) {
-		const r = await pingPitch();
-		console.log(formatPitch(r));
+		const r = await pingWebsiteTemplateHealth();
+		console.log(formatWebsiteTemplateHealth(r));
 	}
 }
 
 console.log(
-	`Mock cron (Worker parity): BASE_URL=${BASE_URL} | tick=${Math.round(TICK_MS / 1000)}s | pitch=${PITCH_BASE} (Ctrl+C to stop)`
+	`Mock cron (Worker parity): BASE_URL=${BASE_URL} | tick=${Math.round(TICK_MS / 1000)}s | website-template=${WEBSITE_TEMPLATE_BASE} (Ctrl+C to stop)`
 );
 
 await tick();


### PR DESCRIPTION
Fixes #38

## Summary
Standardizes naming on **website-template** and removes legacy **pitch-rosetta** / \PITCH_ROSETTA_*\ env and DEBUG aliases.

## Changes
- **apps/cron-worker:** \Env\ no longer includes \PITCH_ROSETTA_URL\; health warm uses \WEBSITE_TEMPLATE_URL\ (or default host). Variable rename in handler; README/wrangler comment wording.
- **apps/website-template:** \DEBUG\ accepts \website-template\ only (drops \pitch-rosetta\). API key chain drops \PITCH_ROSETTA_API_KEY\.
- **scripts/cron-mock.mjs:** \WEBSITE_TEMPLATE_BASE\, \pingWebsiteTemplateHealth\, \ormatWebsiteTemplateHealth\; remove \PITCH_ROSETTA_URL\.

## Deploy / ops
After merge, remove \PITCH_ROSETTA_URL\ from Worker vars if present; rotate any usage of \PITCH_ROSETTA_API_KEY\ to \WEBSITE_TEMPLATE_API_KEY\ or \DEMO_GENERATOR_API_KEY\.

Made with [Cursor](https://cursor.com)