### PR TITLE
fix(website-template): dental-v6 scrolled nav after hero + footer layout

### DIFF
--- a/apps/website-template/renderer/sections/dental-v6.js
+++ b/apps/website-template/renderer/sections/dental-v6.js
@@ -41,6 +41,24 @@ function pickStat(stats, matcher, fallback) {
     : fallback;
 }
 
+const WEEK_DAYS = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"];
+
+function formatAddressLines(address) {
+  if (typeof address !== "string" || !address.trim()) return null;
+  const t = address.trim();
+  if (t.includes("\n")) return t.split("\n").map((s) => s.trim()).filter(Boolean);
+  return t.split(",").map((s) => s.trim()).filter(Boolean);
+}
+
+function formatHoursLines(hours) {
+  if (!hours || typeof hours !== "object") return [];
+  return WEEK_DAYS.map((day) => {
+    const v = hours[day];
+    if (v == null || String(v).trim() === "") return null;
+    return `${day}: ${String(v).trim()}`;
+  }).filter(Boolean);
+}
+
 const DEFAULT_SERVICES = [
   { name: "General Dentistry", description: "Comprehensive preventive care, cleanings, fillings, and oral health exams designed to keep your teeth and gums healthy for life." },
   { name: "Teeth Whitening", description: "Professional-grade whitening treatments that deliver dramatically brighter results in a single visit or with our take-home system — safe, effective, and beautifully natural." },
@@ -103,6 +121,17 @@ function nav(data) {
         btn.setAttribute('aria-expanded', 'false');
       });
     });
+  })();
+  (function () {
+    var nav = document.querySelector('nav');
+    var hero = document.querySelector('.hero');
+    if (!nav || !hero) return;
+    function syncNavScrolled() {
+      nav.classList.toggle('scrolled', hero.getBoundingClientRect().bottom <= 1);
+    }
+    syncNavScrolled();
+    window.addEventListener('scroll', syncNavScrolled, { passive: true });
+    window.addEventListener('resize', syncNavScrolled);
   })();
 </script>`;
 }
@@ -334,11 +363,22 @@ function footer(data) {
   const instagramHref = typeof social.instagram === "string" ? social.instagram : "#";
   const facebookHref = typeof social.facebook === "string" ? social.facebook : "#";
 
+  const phone = b.phone || "(800) 555-0199";
+  const email = b.email || "hello@luminadental.com";
+  const phoneDigits = toTelDigits(phone) || "18005550199";
+  const addrLines = formatAddressLines(b.address) || ["1240 Brightwater Blvd", "Suite 201", "Tampa, FL 33602"];
+  const addressHtml = addrLines.map((line) => escapeHtml(line)).join("<br>");
+  let hourLines = formatHoursLines(b.hours);
+  if (hourLines.length === 0) {
+    hourLines = ["Mon–Fri: 8am – 6pm", "Saturday: 9am – 2pm", "Sunday: Closed"];
+  }
+  const hoursItems = hourLines.map((line) => `<li>${escapeHtml(line)}</li>`).join("\n        ");
+
   return `<footer id="contact">
   <div class="footer-inner">
     <div class="footer-grid">
       <div class="footer-brand">
-        <a href="#" class="footer-brand-logo">${escapeHtml(b.name || "Lumina Dental")}</a>
+        <a href="#home" class="footer-brand-logo">${escapeHtml(b.name || "Lumina Dental")}</a>
         <p class="footer-brand-desc">
           A boutique dental studio dedicated to precision, warmth, and the belief that every smile tells a story worth caring for.
         </p>
@@ -379,14 +419,15 @@ function footer(data) {
         </ul>
       </div>
 
-      <div class="footer-col">
+      <div class="footer-col footer-col-contact">
         <div class="footer-col-title">Contact</div>
         <ul class="footer-links">
-          <li><a href="tel:+${escapeHtml(toTelDigits(b.phone) || "18005550199")}">${escapeHtml(b.phone || "(800) 555-0199")}</a></li>
-          <li><a href="mailto:${escapeHtml(b.email || "hello@luminadental.com")}">${escapeHtml(b.email || "hello@luminadental.com")}</a></li>
-          <li><a href="#" aria-label="Address">1240 Brightwater Blvd<br>Suite 201<br>Tampa, FL 33602</a></li>
-          <li><a href="#">Mon–Fri: 8am – 6pm</a></li>
-          <li><a href="#">Saturday: 9am – 2pm</a></li>
+          <li><a href="tel:+${escapeHtml(phoneDigits)}">${escapeHtml(phone)}</a></li>
+          <li><a href="mailto:${escapeHtml(email)}">${escapeHtml(email)}</a></li>
+        </ul>
+        <address class="footer-address">${addressHtml}</address>
+        <ul class="footer-hours">
+        ${hoursItems}
         </ul>
       </div>
     </div>

--- a/apps/website-template/style-guides/dental/dental-v6.html
+++ b/apps/website-template/style-guides/dental/dental-v6.html
@@ -1172,6 +1172,36 @@
       display: grid;
       grid-template-columns: 1fr;
       gap: 36px;
+      align-items: start;
+    }
+
+    .footer-address {
+      font-size: 13px;
+      color: rgba(255, 255, 255, 0.4);
+      font-weight: 300;
+      font-style: normal;
+      line-height: 1.75;
+      margin: 0;
+    }
+
+    .footer-col-contact .footer-links {
+      margin-bottom: 14px;
+    }
+
+    .footer-hours {
+      list-style: none;
+      margin: 14px 0 0;
+      padding: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    .footer-hours li {
+      font-size: 12px;
+      color: rgba(255, 255, 255, 0.4);
+      font-weight: 300;
+      line-height: 1.5;
     }
 
     .footer-brand-logo {
@@ -1267,10 +1297,10 @@
       font-weight: 500;
     }
 
-    /* Footer — sm breakpoint */
+    /* Footer — sm breakpoint: three equal columns + brand full width */
     @media (min-width: 640px) {
       .footer-grid {
-        grid-template-columns: repeat(2, 1fr);
+        grid-template-columns: repeat(3, minmax(0, 1fr));
         gap: 40px;
       }
 
@@ -1286,7 +1316,7 @@
       }
 
       .footer-grid {
-        grid-template-columns: 2fr 1fr 1fr 1fr;
+        grid-template-columns: minmax(0, 2fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr);
         gap: 48px;
       }
 
@@ -1622,7 +1652,7 @@
       <div class="footer-grid">
 
         <div class="footer-brand">
-          <a href="#" class="footer-brand-logo">Lumina Dental</a>
+          <a href="#home" class="footer-brand-logo">Lumina Dental</a>
           <p class="footer-brand-desc">
             A boutique dental studio dedicated to precision, warmth, and the belief that every smile tells a story worth caring for.
           </p>
@@ -1663,14 +1693,17 @@
           </ul>
         </div>
 
-        <div class="footer-col">
+        <div class="footer-col footer-col-contact">
           <div class="footer-col-title">Contact</div>
           <ul class="footer-links">
             <li><a href="tel:+18005550199">(800) 555-0199</a></li>
             <li><a href="mailto:hello@luminadental.com">hello@luminadental.com</a></li>
-            <li><a href="#">1240 Brightwater Blvd<br>Suite 201<br>Tampa, FL 33602</a></li>
-            <li><a href="#">Mon–Fri: 8am – 6pm</a></li>
-            <li><a href="#">Saturday: 9am – 2pm</a></li>
+          </ul>
+          <address class="footer-address">1240 Brightwater Blvd<br>Suite 201<br>Tampa, FL 33602</address>
+          <ul class="footer-hours">
+            <li>Mon–Fri: 8am – 6pm</li>
+            <li>Saturday: 9am – 2pm</li>
+            <li>Sunday: Closed</li>
           </ul>
         </div>
 
@@ -1687,10 +1720,17 @@
 
   <!-- ─── SCRIPTS ──────────────────────────────────────────────── -->
   <script>
-    // Scroll behavior
-    window.addEventListener('scroll', () => {
-      document.querySelector('nav').classList.toggle('scrolled', window.scrollY > 80);
-    });
+    (function () {
+      var nav = document.querySelector('nav');
+      var hero = document.querySelector('.hero');
+      if (!nav || !hero) return;
+      function syncNavScrolled() {
+        nav.classList.toggle('scrolled', hero.getBoundingClientRect().bottom <= 1);
+      }
+      syncNavScrolled();
+      window.addEventListener('scroll', syncNavScrolled, { passive: true });
+      window.addEventListener('resize', syncNavScrolled);
+    })();
 
     // Mobile menu toggle
     document.querySelector('.nav-hamburger').addEventListener('click', () => {


### PR DESCRIPTION
## What
This PR implements the dental-v6 navigation and footer improvements tracked in the issue below.

## Changes
- **Nav:** After the hero section scrolls out of view, the fixed nav adds the \scrolled\ class so the bar uses a white background and dark logo, links, and hamburger icons. Uses \hero.getBoundingClientRect().bottom\ instead of a fixed pixel scroll offset. The same logic runs in generated HTML (\dental-v6.js\ inline script) and the static style guide (\dental-v6.html\).
- **Footer:** Tablet layout uses three equal columns for Services, Practice, and Contact under a full-width brand row; desktop uses \minmax(0, …)\ tracks. Contact column uses \<address>\ and a \ooter-hours\ list; phone and email stay as real links. Address and hours come from the business payload when present.

Fixes #47

Made with [Cursor](https://cursor.com)