### PR TITLE
feat(admin): email outreach and prospect dashboard updates

### DIFF
--- a/apps/admin/src/lib/components/ui/button/button.svelte
+++ b/apps/admin/src/lib/components/ui/button/button.svelte
@@ -4,7 +4,7 @@
 	import { type VariantProps, tv } from "tailwind-variants";
 
 	export const buttonVariants = tv({
-		base: "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-3 active:not-aria-[haspopup]:translate-y-px aria-invalid:ring-3 [&_svg:not([class*='size-'])]:size-4 group/button inline-flex shrink-0 items-center justify-center whitespace-nowrap transition-all outline-none select-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		base: "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-lg border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-3 active:not-aria-[haspopup]:translate-y-px aria-invalid:ring-3 [&_svg:not([class*='size-'])]:size-4 group/button inline-flex shrink-0 items-center justify-center whitespace-nowrap transition-all outline-none select-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
 		variants: {
 			variant: {
 				default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
@@ -16,12 +16,12 @@
 			},
 			size: {
 				default: "h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
-				xs: "h-6 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
-				sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
+				xs: "h-6 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
+				sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
 				lg: "h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
 				icon: "size-8",
-				"icon-xs": "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-md [&_svg:not([class*='size-'])]:size-3",
-				"icon-sm": "size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-md",
+				"icon-xs": "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",
+				"icon-sm": "size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg",
 				"icon-lg": "size-9",
 			},
 		},

--- a/apps/admin/src/lib/constants.ts
+++ b/apps/admin/src/lib/constants.ts
@@ -36,4 +36,4 @@ export const SIGNATURE_DOMAIN = 'ednsy.com';
  * When the app uses the `dev` PostgREST schema (`SUPABASE_DB_SCHEMA=dev`), outbound prospect
  * emails are delivered here instead of the prospect's stored address.
  */
-export const DEV_OUTBOUND_EMAIL = 'hello@ednsy.com';
+export const DEV_OUTBOUND_EMAIL = 'test@ednsy.com';

--- a/apps/admin/src/lib/server/generateEmailCopy.ts
+++ b/apps/admin/src/lib/server/generateEmailCopy.ts
@@ -6,42 +6,35 @@ import { serverError } from '$lib/server/logger';
 const GEMINI_API_KEY = env.GEMINI_API_KEY;
 const GEMINI_MODEL = 'gemini-2.5-flash';
 
-/** AI-generated subject and body intro in "Prospects Receive" style: cheeky, fun, not too serious. */
-export type EmailCopy = { subject: string; bodyIntro: string };
+/**
+ * Optional AI-written opening paragraph for the fixed upgrade-pitch email template in send.ts.
+ * Subject line and the rest of the body are assembled server-side.
+ */
+export type EmailCopy = { openingHook?: string; bodyIntro?: string };
 export type GenerateEmailCopyResult = {
+	/** null = generation failed (e.g. API/parse error). Empty object = use template default opening. */
 	copy: EmailCopy | null;
 	promptSource: 'override' | 'default';
 	error?: string;
 };
 
 const EMAIL_COPY_JSON_SCHEMA_INLINE = `
-Return ONLY a single JSON object (no markdown, no explanation) with these exact keys:
+Return ONLY a single JSON object (no markdown, no explanation) with this key:
 {
-  "subject": "string (one short line, friendly subject line for the email)",
-  "bodyIntro": "string (exactly 3 parts, plain text, separated by double newlines. Part 1: Greeting only, e.g. 'Hey there,' or 'Hi there,'. Do NOT use company name in the greeting. Part 2: One short paragraph: we built a free demo site for [company] using their Google listing — their services, their location, their reviews. Part 3: One short paragraph: we also added an AI agent that handles inquiries and books consultations automatically. Do NOT include the demo link, 'Take a look...', or signature; we add those. Use the business/company name naturally in paragraph 2/3.)"
+  "openingHook": "string (one short paragraph, plain text). Describe specific performance or conversion gaps on their current site: mobile experience, lead capture, after-hours calls, or speed. Mention the business name naturally. Do NOT include a greeting (we add Hi there), bullet lists, demo link, CTA, signature, or markdown."
 }`.trim();
 
-/** Default prompt template for email copy. Use {{company}}, {{industry}}, {{senderName}}. */
-export const DEFAULT_EMAIL_COPY_PROMPT = `You are writing a short cold outreach email for Ed & Sy Admin. The sender has already built a personalized demo website for this prospect using their Google Business Profile. Your job is to write a subject line and the body intro only. Tone: friendly, clear, confident. Not corporate.
-
-Required structure for bodyIntro (3 parts, separate with double newlines):
-1. Greeting: "Hey there," or "Hi there,". Do NOT use company name in the greeting.
-2. One short paragraph: We built a free demo site for [company] using their Google listing — their services, their location, their reviews. Keep it natural and specific to the business.
-3. One short paragraph: We also added an AI agent that handles inquiries and books consultations automatically.
-
-Example flow (adapt to company/industry):
-Hey [Name],
-We built a free demo site for [Company] using your Google listing — your services, your location, your reviews.
-Also added an AI agent that handles inquiries and books consultations automatically.
+/** Default prompt for the optional opening paragraph. Use {{company}}, {{industry}}, {{senderName}}. */
+export const DEFAULT_EMAIL_COPY_PROMPT = `You help write one optional paragraph for a cold outreach email. The email uses a fixed HTML template: the sender already built a high-performance demo site for the prospect. Your only job is the openingHook: one paragraph that sounds observant and professional about gaps on their current site (mobile, lead capture, after-hours handling, speed, SEO—pick what fits {{industry}}).
 
 Context:
 - Business/company name: {{company}}
 - Industry: {{industry}}
-- Sender name (used in signature by us): {{senderName}}
+- Sender name (signature is added separately): {{senderName}}
 
 Rules:
-- subject: One short line. Friendly, clear, can mention demo or free site.
-- bodyIntro: Exactly the 3 parts above. No demo link, no "Take a look...", no signature — we add those. Use the business/company name naturally.
+- openingHook: A single paragraph only. No Hi/Hello, no bullets, no link, no signature.
+- Tone: confident, consultative, like the example: "I noticed a few performance gaps on the current [Company] site—specifically regarding…"
 
 ${EMAIL_COPY_JSON_SCHEMA_INLINE}`;
 
@@ -81,19 +74,14 @@ function repairJsonNewlines(raw: string): string {
 	return result;
 }
 
-/** Accept common field variants Gemini may return for body intro content. */
-function normalizeEmailCopyShape(input: unknown): { subject?: string; bodyIntro?: string } {
+/** Accept common field variants Gemini may return for the opening paragraph. */
+function normalizeEmailCopyShape(input: unknown): { openingHook?: string } {
 	if (typeof input !== 'object' || input === null) return {};
 	const obj = input as Record<string, unknown>;
-	const subjectCandidates: unknown[] = [
-		obj.subject,
-		obj.subject_line,
-		obj.subjectLine,
-		obj.title,
-		obj.headline
-	];
-	const subject = subjectCandidates.find((v) => typeof v === 'string') as string | undefined;
-	const bodyIntroCandidates: unknown[] = [
+	const candidates: unknown[] = [
+		obj.openingHook,
+		obj.opening_hook,
+		obj.hook,
 		obj.bodyIntro,
 		obj.body_intro,
 		obj.body,
@@ -103,112 +91,64 @@ function normalizeEmailCopyShape(input: unknown): { subject?: string; bodyIntro?
 		obj.email_body,
 		obj.copy
 	];
-	let bodyIntro = bodyIntroCandidates.find((v) => typeof v === 'string') as string | undefined;
-	if (!bodyIntro) {
+	let openingHook = candidates.find((v) => typeof v === 'string') as string | undefined;
+	if (!openingHook) {
 		const paragraphs = obj.paragraphs;
 		if (Array.isArray(paragraphs)) {
 			const textParts = paragraphs.filter((p) => typeof p === 'string') as string[];
-			if (textParts.length > 0) bodyIntro = textParts.join('\n\n');
+			if (textParts.length > 0) openingHook = textParts.join('\n\n');
 		}
 	}
-	if (!subject || !bodyIntro) {
-		const nestedCandidates = [obj.data, obj.result, obj.output, obj.email, obj.response];
-		for (const candidate of nestedCandidates) {
+	if (!openingHook) {
+		for (const candidate of [obj.data, obj.result, obj.output, obj.email, obj.response]) {
 			const nested = normalizeEmailCopyShape(candidate);
-			if (!bodyIntro && nested.bodyIntro) bodyIntro = nested.bodyIntro;
-			if (!subject && nested.subject) {
-				return { subject: nested.subject, bodyIntro };
-			}
+			if (nested.openingHook) return nested;
 		}
 	}
-	return { subject, bodyIntro };
+	return { openingHook };
 }
 
-function parsePlainTextEmailCopy(text: string): { subject?: string; bodyIntro?: string } {
+function parsePlainTextEmailCopy(text: string): { openingHook?: string } {
 	const cleaned = text.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/i, '').trim();
 	if (!cleaned) return {};
 	const lines = cleaned.split('\n').map((line) => line.trim()).filter(Boolean);
 	if (lines.length === 0) return {};
-	const subjectLine = lines.find((line) => /^subject\s*:/i.test(line));
-	let subject = subjectLine?.replace(/^subject\s*:/i, '').trim();
-	let bodyLines = lines;
-	if (subjectLine) {
-		const idx = lines.indexOf(subjectLine);
-		bodyLines = lines.slice(0, idx).concat(lines.slice(idx + 1));
-	}
-	const bodyIntro = bodyLines.join('\n');
-	if (!subject && bodyIntro) subject = lines[0].slice(0, 90);
-	return { subject, bodyIntro: bodyIntro || undefined };
+	const hookLine = lines.find((line) => /^openinghook\s*:/i.test(line));
+	let openingHook = hookLine?.replace(/^openinghook\s*:/i, '').trim();
+	if (!openingHook) openingHook = lines.join('\n');
+	return { openingHook: openingHook || undefined };
 }
 
-function sanitizeSubject(raw: string): string {
-	let s = raw.replace(/\r/g, '').trim();
-	// Subject must be one line; keep only first non-empty line.
-	s = s.split('\n').map((line) => line.trim()).find(Boolean) ?? '';
-	// Strip common leaked tokens and markdown noise.
-	s = s.replace(/^subject\s*:\s*/i, '').replace(/^["']|["']$/g, '').trim();
-	// If still obviously a body/CTA artifact, reject.
-	const lower = s.toLowerCase();
-	if (
-		!s ||
-		lower.includes('view your demo') ||
-		lower.includes('take a look') ||
-		lower.includes('ednsy.com') ||
-		lower.includes('http://') ||
-		lower.includes('https://')
-	) {
-		return '';
-	}
-	// Very short/weak subject lines (e.g. "A") look broken in inboxes.
-	if (s.length < 8) return '';
-	const wordCount = s.split(/\s+/).filter(Boolean).length;
-	if (wordCount < 2) return '';
-	return s.slice(0, 110).trim();
-}
-
-function sanitizeBodyIntro(raw: string): string {
+function sanitizeOpeningHook(raw: string): string {
 	let text = raw.replace(/\r/g, '').trim();
-	// Remove CTA/signature/footer fragments that must be appended by send.ts only.
-	const bannedLine = /(view your demo|take a look and let us know|ednsy\.com|^-\s|http:\/\/|https:\/\/)/i;
+	const bannedLine =
+		/(view your demo|view the .* upgrade|take a look|ednsy\.com|^-\s|http:\/\/|https:\/\/)/i;
 	const kept = text
 		.split('\n')
 		.map((line) => line.trim())
-		.filter((line) => line.length > 0 && !bannedLine.test(line));
-	text = kept.join('\n');
-	// Normalize excessive blank lines.
-	text = text.replace(/\n{3,}/g, '\n\n').trim();
+		.filter((line) => line.length > 0 && !bannedLine.test(line) && !/^(hi|hey|hello)[,!\s]*$/i.test(line));
+	text = kept.join(' ').replace(/\s{2,}/g, ' ').trim();
+	if (text.length > 600) text = text.slice(0, 600).trim();
 	return text;
 }
 
-function looksLikeBrokenModelOutput(subject: string, bodyIntro: string): boolean {
-	const combined = `${subject}\n${bodyIntro}`.toLowerCase();
-	// Reject obvious JSON fragments or leaked schema/output wrappers.
+function looksLikeBrokenModelOpening(opening: string): boolean {
+	const combined = opening.toLowerCase();
 	if (
-		combined.includes('"subject"') ||
+		combined.includes('"openinghook"') ||
 		combined.includes('"bodyintro"') ||
-		combined.includes('"body_intro"') ||
 		combined.includes('return only a single json object')
 	) {
 		return true;
 	}
-	// Reject braces-heavy fragments that usually indicate partial JSON.
 	const braceCount = (combined.match(/[{}]/g) ?? []).length;
 	if (braceCount >= 2) return true;
 	return false;
 }
 
-function buildDeterministicBodyIntro(company: string): string {
-	return [
-		`Hi there,`,
-		`We built a free demo site for ${company} using your Google listing — your services, your location, and your reviews.`,
-		`We also added an AI agent that handles inquiries and books consultations automatically.`
-	].join('\n\n');
-}
-
 /**
- * Generate subject line and email body intro for a prospect. Structure: greeting, demo-from-Google
- * message, AI-agent message. CTA link, closing line, and signature are added in send.ts.
- * Returns null if Gemini is not configured or the request fails.
+ * Optional AI opening paragraph for the upgrade-pitch template. Returns copy: null on hard failure;
+ * copy: {} when generation succeeded but the hook is omitted or stripped (use default opening in send.ts).
  */
 export async function generateEmailCopy(
 	prospect: Prospect,
@@ -283,28 +223,21 @@ export async function generateEmailCopy(
 		if (typeof parsed !== 'object' || parsed === null) {
 			return { copy: null, promptSource: resolved.source, error: 'Gemini response was not a JSON object' };
 		}
-		let { subject, bodyIntro } = normalizeEmailCopyShape(parsed);
-		if (!subject || !bodyIntro) {
+		let { openingHook } = normalizeEmailCopyShape(parsed);
+		if (!openingHook?.trim()) {
 			const plainTextParsed = parsePlainTextEmailCopy(text);
-			if (!subject && plainTextParsed.subject) subject = plainTextParsed.subject;
-			if (!bodyIntro && plainTextParsed.bodyIntro) bodyIntro = plainTextParsed.bodyIntro;
+			if (plainTextParsed.openingHook) openingHook = plainTextParsed.openingHook;
 		}
-		if (typeof subject !== 'string' || typeof bodyIntro !== 'string') {
-			return { copy: null, promptSource: resolved.source, error: 'Gemini response missed subject or bodyIntro' };
+		if (typeof openingHook !== 'string' || !openingHook.trim()) {
+			return { copy: {}, promptSource: resolved.source };
 		}
-		const cleanSubject = sanitizeSubject(subject);
-		const cleanBodyIntro = sanitizeBodyIntro(bodyIntro);
-		if (!cleanBodyIntro) {
-			return { copy: null, promptSource: resolved.source, error: 'Gemini response had empty fields' };
-		}
-		const finalSubject = cleanSubject || `I built something for ${company}`;
-		let finalBodyIntro = cleanBodyIntro;
-		if (looksLikeBrokenModelOutput(finalSubject, finalBodyIntro)) {
-			finalBodyIntro = buildDeterministicBodyIntro(company);
+		let clean = sanitizeOpeningHook(openingHook);
+		if (!clean || looksLikeBrokenModelOpening(clean)) {
+			return { copy: {}, promptSource: resolved.source };
 		}
 
 		return {
-			copy: { subject: finalSubject, bodyIntro: finalBodyIntro },
+			copy: { openingHook: clean },
 			promptSource: resolved.source
 		};
 	} catch (e) {

--- a/apps/admin/src/lib/server/send.ts
+++ b/apps/admin/src/lib/server/send.ts
@@ -46,9 +46,15 @@ function getTwilioConfig() {
 	return { accountSid, authToken, fromNumber };
 }
 
-/** Default email subject per PRD (fallback when AI is not used). */
+/** Demo outreach subject: "{company} / site upgrade prototype" (company lowercased). */
+export function getUpgradePitchSubject(companyName: string): string {
+	const c = (companyName || 'your business').trim() || 'your business';
+	return `${c.toLowerCase()} / site upgrade prototype`;
+}
+
+/** @deprecated Use {@link getUpgradePitchSubject}; kept for call sites that still reference the old name. */
 export function getDefaultEmailSubject(companyName: string): string {
-	return `I built something for ${companyName}`;
+	return getUpgradePitchSubject(companyName);
 }
 
 /** Subject for alternate-offer email (AI agent, voice AI, SEO — no demo). */
@@ -99,36 +105,78 @@ export function getEmailSignatureLine(
 	return `- ${senderName} | ${SIGNATURE_DOMAIN}`;
 }
 
+/** Plain closing line after "Best," (no leading dash). */
+function getEmailClosingSignatureLine(senderName: string, signatureOverride: string | null): string {
+	const line = getEmailSignatureLine(senderName, signatureOverride);
+	return line.replace(/^\s*-\s+/, '').trim() || `${senderName} | ${SIGNATURE_DOMAIN}`;
+}
+
+function techStackPhraseForIndustry(industry: string): string {
+	const i = (industry || '').toLowerCase();
+	if (/(dental|dentist|orthodont)/.test(i)) return 'at the clinic';
+	if (/(medical|health|clinic|physician|doctor|vet|veterinary)/.test(i)) return 'at your practice';
+	return 'for your business';
+}
+
+function defaultUpgradeOpeningParagraph(company: string): string {
+	const c = company.trim() || 'your business';
+	return `I noticed a few performance gaps on the current ${c} site—specifically regarding mobile lead capture and how after-hours calls are handled.`;
+}
+
 /**
- * Build email HTML from AI-generated body intro (plain text paragraphs). Appends CTA link
- * (👉 VIEW YOUR DEMO), closing line, signature (user override or default - Name | ednsy.com), legal footer, and open pixel.
- * Tracking is active: link = /api/demo/click, pixel = /api/demo/open.
+ * High-conversion demo outreach HTML: upgrade pitch, trackable CTA, four pillars, 24h close.
+ * Tracking: link = /api/demo/click, pixel = /api/demo/open.
+ */
+export function buildEmailBodyUpgradePitch(
+	prospect: Prospect,
+	senderName: string,
+	origin: string,
+	signatureOverride: string | null | undefined,
+	options?: { openingHook?: string | null }
+): string {
+	const company = (prospect.companyName || 'your business').trim() || 'your business';
+	const companyCta = escapeHtml(company.toUpperCase());
+	const trackableLink = `${origin}/api/demo/click?p=${encodeURIComponent(prospect.id)}`;
+	const pixelUrl = `${origin}/api/demo/open?p=${encodeURIComponent(prospect.id)}`;
+	const openingPlain = (options?.openingHook ?? '').trim() || defaultUpgradeOpeningParagraph(company);
+	const openingHtml = `<p>${escapeHtml(openingPlain).replace(/\n/g, '<br />\n')}</p>`;
+	const closingSig = escapeHtml(getEmailClosingSignatureLine(senderName, signatureOverride ?? null));
+	const stackPhrase = escapeHtml(techStackPhraseForIndustry(prospect.industry ?? ''));
+	const html = `
+<p>Hi there,</p>
+${openingHtml}
+<p>Instead of sending a list of suggestions, I just went ahead and built a high-performance version of the site to show you the difference.</p>
+<p><a href="${trackableLink}">👉 VIEW THE ${companyCta} UPGRADE</a></p>
+<p>I&apos;ve integrated four specific upgrades into this demo:</p>
+<ul style="margin:0 0 1em 1.25em;padding:0;">
+<li><strong>Voice AI:</strong> It answers your office line when the front desk is busy or closed to book patients.</li>
+<li><strong>Chat AI:</strong> Handles insurance and basic FAQ instantly to stop &quot;bounce rates.&quot;</li>
+<li><strong>Lead Capture:</strong> A high-conversion flow designed to get more bookings from your existing traffic.</li>
+<li><strong>SEO Core:</strong> Rebuilt the metadata and site speed to rank higher in local search.</li>
+</ul>
+<p>I&apos;m not sure if you&apos;re currently looking to upgrade the tech stack ${stackPhrase}, but I thought you&apos;d want to see what&apos;s possible with the new AI tools.</p>
+<p>If you like the speed and the AI features, I can show you how to swap this with your current site in about 24 hours.</p>
+<p>Best,</p>
+<p>${closingSig}</p>
+<img src="${pixelUrl}" width="1" height="1" alt="" style="display:block;width:1px;height:1px;border:0;" />
+`.trim();
+	return html;
+}
+
+/**
+ * @deprecated Prefer {@link buildEmailBodyUpgradePitch}. Kept for any external references.
  */
 export function buildEmailBodyFromAiIntro(
 	prospect: Prospect,
-	demoLink: string,
+	_demoLink: string,
 	senderName: string,
 	origin: string,
 	bodyIntro: string,
 	signatureOverride?: string | null
 ): string {
-	const trackableLink = `${origin}/api/demo/click?p=${encodeURIComponent(prospect.id)}`;
-	const pixelUrl = `${origin}/api/demo/open?p=${encodeURIComponent(prospect.id)}`;
-	const paragraphs = bodyIntro
-		.split(/\n\n+/)
-		.map((p) => p.trim())
-		.filter(Boolean)
-		.map((p) => `<p>${escapeHtml(p)}</p>`)
-		.join('\n');
-	const signatureLine = getEmailSignatureLine(senderName, signatureOverride ?? null);
-	const html = `
-${paragraphs}
-<p><a href="${trackableLink}">👉 VIEW YOUR DEMO</a></p>
-<p>Take a look and let us know what you think.</p>
-<p>${escapeHtml(signatureLine)}</p>
-<img src="${pixelUrl}" width="1" height="1" alt="" style="display:block;width:1px;height:1px;border:0;" />
-`.trim();
-	return html;
+	return buildEmailBodyUpgradePitch(prospect, senderName, origin, signatureOverride ?? null, {
+		openingHook: bodyIntro
+	});
 }
 
 /**
@@ -137,22 +185,11 @@ ${paragraphs}
  */
 export function buildEmailBody(
 	prospect: Prospect,
-	demoLink: string,
+	_demoLink: string,
 	senderName: string,
 	origin: string
 ): string {
-	const company = prospect.companyName || 'your business';
-	const trackableLink = `${origin}/api/demo/click?p=${encodeURIComponent(prospect.id)}`;
-	const pixelUrl = `${origin}/api/demo/open?p=${encodeURIComponent(prospect.id)}`;
-	const html = `
-<p>Hi,</p>
-<p>I built a free website demo for ${company}. Take 30 seconds to see it:</p>
-<p><a href="${trackableLink}">View your demo</a></p>
-<p>${trackableLink}</p>
-<p>— ${senderName}</p>
-<img src="${pixelUrl}" width="1" height="1" alt="" style="display:block;width:1px;height:1px;border:0;" />
-`.trim();
-	return html;
+	return buildEmailBodyUpgradePitch(prospect, senderName, origin, null, {});
 }
 
 export type EmailTemplateVars = {
@@ -212,6 +249,55 @@ export function buildEmailBodyForUser(
 		return buildEmailBodyFromTemplate(customEmailHtml.trim(), vars);
 	}
 	return buildEmailBody(prospect, demoLink, senderName, origin);
+}
+
+/** Optional AI paragraph for the upgrade-pitch template (see {@link buildEmailBodyUpgradePitch}). */
+export type DemoEmailAiCopy = { openingHook?: string; bodyIntro?: string };
+
+export type DemoEmailGenerationResult = {
+	copy: DemoEmailAiCopy | null;
+	promptSource: 'override' | 'default';
+	error?: string;
+};
+
+/**
+ * Subject + HTML for “send demo” email: upgrade-pitch template, optional custom user HTML template,
+ * optional AI opening paragraph. Fails when a custom Email AI prompt is active but generation returned no copy.
+ */
+export function resolveDemoOutreachEmail(
+	prospect: Prospect,
+	senderName: string,
+	linkOrigin: string,
+	emailHtmlTemplate: string | null,
+	emailSignatureOverride: string | null,
+	ai: DemoEmailGenerationResult
+): { subject: string; html: string } | { error: string } {
+	if (ai.copy === null && ai.promptSource === 'override') {
+		return {
+			error:
+				ai.error ??
+				'AI email generation failed while a custom Email AI prompt override is active. The email was not sent.'
+		};
+	}
+	const subject = getUpgradePitchSubject(prospect.companyName || 'your business');
+	const hookRaw = ai.copy?.openingHook?.trim() || ai.copy?.bodyIntro?.trim();
+	const openingHook = hookRaw && hookRaw.length > 0 ? hookRaw : null;
+	if (emailHtmlTemplate?.trim()) {
+		return {
+			subject,
+			html: buildEmailBodyForUser(
+				prospect,
+				prospect.demoLink ?? '',
+				senderName,
+				linkOrigin,
+				emailHtmlTemplate
+			)
+		};
+	}
+	return {
+		subject,
+		html: buildEmailBodyUpgradePitch(prospect, senderName, linkOrigin, emailSignatureOverride, { openingHook })
+	};
 }
 
 /** Default SMS body per PRD. First name not in schema; use company or "there". CASL: opt-out. */

--- a/apps/admin/src/routes/dashboard/+page.server.ts
+++ b/apps/admin/src/routes/dashboard/+page.server.ts
@@ -30,14 +30,12 @@ import { serverInfo, serverError } from '$lib/server/logger';
 import {
 	sendEmail,
 	sendSms,
-	getDefaultEmailSubject,
-	buildEmailBodyForUser,
-	buildEmailBodyFromAiIntro,
 	buildSmsBody,
 	getSendConfigured,
 	getOriginForOutgoingLinks,
 	getDemoPublicOrigin,
-	isTwilioConfigured
+	isTwilioConfigured,
+	resolveDemoOutreachEmail
 } from '$lib/server/send';
 import { generateEmailCopy } from '$lib/server/generateEmailCopy';
 import { getTemplates } from '$lib/server/templates';
@@ -343,31 +341,21 @@ export const actions: Actions = {
 			if (prospect.email?.trim()) {
 				const linkOrigin = getOriginForOutgoingLinks(url.origin);
 				const ai = await generateEmailCopy(prospect, senderName);
-				if (!ai.copy && ai.promptSource === 'override') {
-					const reason =
-						ai.error ??
-						'AI email generation failed while a custom Email AI prompt override is active.';
+				const resolved = resolveDemoOutreachEmail(
+					prospect,
+					senderName,
+					linkOrigin,
+					templates.emailHtml,
+					emailSignatureOverride,
+					ai
+				);
+				if ('error' in resolved) {
+					const reason = resolved.error;
 					errors.push(`${prospect.companyName || id}: ${reason} Email not sent.`);
 					serverError('sendDemos', reason, { prospectId: id, to: prospect.email.trim() });
 					continue;
 				}
-				const subject = ai.copy?.subject ?? getDefaultEmailSubject(prospect.companyName || 'your business');
-				const html = ai.copy
-					? buildEmailBodyFromAiIntro(
-							prospect,
-							demoLink,
-							senderName,
-							linkOrigin,
-							ai.copy.bodyIntro,
-							emailSignatureOverride
-						)
-					: buildEmailBodyForUser(
-							prospect,
-							demoLink,
-							senderName,
-							linkOrigin,
-							templates.emailHtml
-						);
+				const { subject, html } = resolved;
 				const result = await sendEmail(prospect.email.trim(), subject, html, {
 					userId: user.id,
 					appUserEmail: user.email

--- a/apps/admin/src/routes/dashboard/prospects/+page.server.ts
+++ b/apps/admin/src/routes/dashboard/prospects/+page.server.ts
@@ -64,14 +64,12 @@ import { serverInfo, serverError } from '$lib/server/logger';
 import {
 	sendEmail,
 	sendSms,
-	getDefaultEmailSubject,
-	buildEmailBodyForUser,
-	buildEmailBodyFromAiIntro,
 	buildSmsBody,
 	getSendConfigured,
 	getOriginForOutgoingLinks,
 	getDemoPublicOrigin,
-	isTwilioConfigured
+	isTwilioConfigured,
+	resolveDemoOutreachEmail
 } from '$lib/server/send';
 import { generateEmailCopy } from '$lib/server/generateEmailCopy';
 import { getTemplates } from '$lib/server/templates';
@@ -550,31 +548,21 @@ export const actions: Actions = {
 			if (prospect.email?.trim()) {
 				const linkOrigin = getOriginForOutgoingLinks(url.origin);
 				const ai = await generateEmailCopy(prospect, senderName);
-				if (!ai.copy && ai.promptSource === 'override') {
-					const reason =
-						ai.error ??
-						'AI email generation failed while a custom Email AI prompt override is active.';
+				const resolved = resolveDemoOutreachEmail(
+					prospect,
+					senderName,
+					linkOrigin,
+					templates.emailHtml,
+					emailSignatureOverride,
+					ai
+				);
+				if ('error' in resolved) {
+					const reason = resolved.error;
 					errors.push(`${prospect.companyName || id}: ${reason} Email not sent.`);
 					serverError('sendDemos', reason, { prospectId: id, to: prospect.email.trim() });
 					continue;
 				}
-				const subject = ai.copy?.subject ?? getDefaultEmailSubject(prospect.companyName || 'your business');
-				const html = ai.copy
-					? buildEmailBodyFromAiIntro(
-							prospect,
-							demoLink,
-							senderName,
-							linkOrigin,
-							ai.copy.bodyIntro,
-							emailSignatureOverride
-						)
-					: buildEmailBodyForUser(
-							prospect,
-							demoLink,
-							senderName,
-							linkOrigin,
-							templates.emailHtml
-						);
+				const { subject, html } = resolved;
 				const result = await sendEmail(prospect.email.trim(), subject, html, {
 					userId: user.id,
 					appUserEmail: user.email

--- a/apps/admin/src/routes/dashboard/prospects/[id]/+page.server.ts
+++ b/apps/admin/src/routes/dashboard/prospects/[id]/+page.server.ts
@@ -30,15 +30,13 @@ function canRunInsightsAndDemo(prospect: { flagged?: boolean; flaggedReason?: st
 import {
 	sendEmail,
 	sendSms,
-	getDefaultEmailSubject,
 	getAlternateOfferSubject,
-	buildEmailBodyForUser,
-	buildEmailBodyFromAiIntro,
 	buildEmailBodyAlternateOffer,
 	buildSmsBody,
 	getSendConfigured,
 	getOriginForOutgoingLinks,
-	isTwilioConfigured
+	isTwilioConfigured,
+	resolveDemoOutreachEmail
 } from '$lib/server/send';
 import { generateEmailCopy } from '$lib/server/generateEmailCopy';
 import { getTemplates } from '$lib/server/templates';
@@ -314,31 +312,18 @@ export const actions: Actions = {
 		let sent = 0;
 		if (prospect.email?.trim()) {
 			const ai = await generateEmailCopy(prospect, senderName);
-			if (!ai.copy && ai.promptSource === 'override') {
-				return fail(502, {
-					message:
-						ai.error ??
-						'AI email generation failed while a custom Email AI prompt override is active. The email was not sent.'
-				});
+			const resolved = resolveDemoOutreachEmail(
+				prospect,
+				senderName,
+				linkOrigin,
+				templates.emailHtml,
+				emailSignatureOverride,
+				ai
+			);
+			if ('error' in resolved) {
+				return fail(502, { message: resolved.error });
 			}
-			const subject =
-				ai.copy?.subject ?? getDefaultEmailSubject(prospect.companyName || 'your business');
-			const html = ai.copy
-				? buildEmailBodyFromAiIntro(
-						prospect,
-						prospect.demoLink,
-						senderName,
-						linkOrigin,
-						ai.copy.bodyIntro,
-						emailSignatureOverride
-					)
-				: buildEmailBodyForUser(
-						prospect,
-						prospect.demoLink,
-						senderName,
-						linkOrigin,
-						templates.emailHtml
-					);
+			const { subject, html } = resolved;
 			const result = await sendEmail(prospect.email.trim(), subject, html, {
 				userId: user.id,
 				appUserEmail: user.email

--- a/apps/admin/src/routes/dashboard/prospects/[id]/+page.svelte
+++ b/apps/admin/src/routes/dashboard/prospects/[id]/+page.svelte
@@ -91,8 +91,6 @@
 	let sendConfirmOpen = $state(false);
 	let sendAlternateConfirmOpen = $state(false);
 	let sendingEmail = $state(false);
-	let sendForm: HTMLFormElement | null = $state(null);
-	let sendAlternateForm: HTMLFormElement | null = $state(null);
 	/** Set true after Approve demo succeeds so Send button appears immediately before refetch. */
 	let approvedJustNow = $state(false);
 	let editingEmail = $state(false);
@@ -102,7 +100,7 @@
 
 	const isDevSchema = $derived(data.supabaseDbSchema === 'dev');
 	const hasProspectEmail = $derived(!!(prospect.email ?? '').trim());
-	/** Address messages and send confirmations use this (dev → hello@ednsy.com when a prospect email exists). */
+	/** Address messages and send confirmations use this (dev → test@ednsy.com when a prospect email exists). */
 	const outboundEmailTargetDisplay = $derived(
 		isDevSchema && hasProspectEmail ? DEV_OUTBOUND_EMAIL : (prospect.email ?? '').trim() || '(no email set)'
 	);
@@ -372,12 +370,7 @@
 		}
 	}
 
-	/** Submit send-demo form (use:enhance handles the request with correct SvelteKit behavior). */
-	function submitSend() {
-		if (!sendForm || sendingEmail) return;
-		ensureAupInput(sendForm);
-		sendForm.requestSubmit();
-	}
+	const sendDemoFormId = $derived(`send-demo-form-${prospect.id}`);
 
 	function enhanceAnalyze(input: FormData | { formData: FormData }) {
 		const formData = input instanceof FormData ? input : input?.formData;
@@ -439,12 +432,7 @@
 		};
 	}
 
-	/** Submit alternate-offer form (use:enhance handles the request with correct SvelteKit behavior). */
-	function submitSendAlternate() {
-		if (!sendAlternateForm || sendingEmail) return;
-		ensureAupInput(sendAlternateForm);
-		sendAlternateForm.requestSubmit();
-	}
+	const sendAlternateFormId = $derived(`send-alternate-form-${prospect.id}`);
 </script>
 
 <svelte:head>
@@ -476,9 +464,10 @@
 		{:else if primaryAction?.type === 'sendAlternateOffer'}
 			<div class="shrink-0">
 				<form
-					bind:this={sendAlternateForm}
+					id={sendAlternateFormId}
 					method="POST"
 					action="?/sendAlternateOffer"
+					onsubmit={(e) => ensureAupInput(e.currentTarget)}
 					use:enhance={() => {
 						sendingEmail = true;
 						return async ({ result }) => {
@@ -513,13 +502,22 @@
 								<AlertDialog.Title>Send outreach email?</AlertDialog.Title>
 								<AlertDialog.Description>
 									An email about AI agent, voice AI, and SEO will be sent to {outboundEmailTargetDisplay}. No demo link will be included.
+									{#if !canSend}
+										<span class="mt-3 block text-destructive">
+											Connect Gmail in Dashboard → Integrations before sending.
+										</span>
+									{/if}
 									<br><br>
 									<strong>Sending means you accept the Acceptable Use Policy (AUP).</strong>
 								</AlertDialog.Description>
 							</AlertDialog.Header>
 							<AlertDialog.Footer>
 								<AlertDialog.Cancel disabled={sendingEmail}>Cancel</AlertDialog.Cancel>
-								<AlertDialog.Action type="button" disabled={sendingEmail} onclick={() => { submitSendAlternate(); }}>
+								<AlertDialog.Action
+									type="submit"
+									form={sendAlternateFormId}
+									disabled={sendingEmail || !canSend || !(prospect.email ?? '').trim()}
+								>
 									{#if sendingEmail}<LoaderCircle class="size-4 mr-2 animate-spin" aria-hidden="true" />{/if}
 									{sendingEmail ? 'Sending…' : 'Send email'}
 								</AlertDialog.Action>
@@ -627,9 +625,10 @@
 		{:else if isApprovedForSend}
 			<div class="shrink-0">
 				<form
-					bind:this={sendForm}
+					id={sendDemoFormId}
 					method="POST"
 					action="?/sendDemos"
+					onsubmit={(e) => ensureAupInput(e.currentTarget)}
 					use:enhance={() => {
 						sendingEmail = true;
 						return async ({ result }) => {
@@ -654,14 +653,8 @@
 						<AlertDialog.Trigger
 							type="button"
 							class={cn(buttonVariants({ size: 'lg' }), 'inline-flex items-center justify-center')}
-							disabled={!canSend || !(prospect.email ?? '').trim()}
-							title={
-								!(prospect.email ?? '').trim()
-									? 'Add an email for this prospect to send'
-									: !canSend
-										? 'Connect Gmail in Integrations to send email'
-										: ''
-							}
+							disabled={!(prospect.email ?? '').trim()}
+							title={!(prospect.email ?? '').trim() ? 'Add an email for this prospect to send' : ''}
 							onclick={() => (sendConfirmOpen = true)}
 						>
 							<Send class="size-4 mr-2" />
@@ -672,13 +665,22 @@
 								<AlertDialog.Title>Send demo to this client?</AlertDialog.Title>
 								<AlertDialog.Description>
 									An email with the demo link will be sent to {outboundEmailTargetDisplay}.
+									{#if !canSend}
+										<span class="mt-3 block text-destructive">
+											Connect Gmail in Dashboard → Integrations before sending.
+										</span>
+									{/if}
 									<br><br>
 									<strong>Sending means you accept the Acceptable Use Policy (AUP).</strong>
 								</AlertDialog.Description>
 							</AlertDialog.Header>
 							<AlertDialog.Footer>
 								<AlertDialog.Cancel disabled={sendingEmail}>Cancel</AlertDialog.Cancel>
-								<AlertDialog.Action type="button" disabled={sendingEmail} onclick={() => { submitSend(); }}>
+								<AlertDialog.Action
+									type="submit"
+									form={sendDemoFormId}
+									disabled={sendingEmail || !canSend || !(prospect.email ?? '').trim()}
+								>
 									{#if sendingEmail}<LoaderCircle class="size-4 mr-2 animate-spin" aria-hidden="true" />{/if}
 									{sendingEmail ? 'Sending…' : 'Send email'}
 								</AlertDialog.Action>


### PR DESCRIPTION
This PR ships the outstanding admin app changes on \chore/admin-shadcn-theme-css-split-57\: refactored email copy generation and send helpers, dashboard/prospect server loader updates, and prospect detail UI adjustments, plus small button/constants tweaks.

**Intentionally excluded from this PR:** \pps/admin/docs/data/google-places_apollo-accounts-import.csv\ (and the rest of \pps/admin/docs/data/\) remain local-only. Scratch files \.github-pr-body-temp.md\ and \_patch_body.cjs\ were not committed.

Per repo workflow, add \Fixes #<issue>\ or \Closes #<issue>\ here once you have the tracking issue number.

Made with [Cursor](https://cursor.com)