### PR TITLE
feat(stitch): async demo generator, admin integration, cron warm ping

### DIFF
--- a/apps/cron-worker/src/index.ts
+++ b/apps/cron-worker/src/index.ts
@@ -4,6 +4,7 @@
  * Cloudflare Worker: runs on a schedule.
  * - Admin app: calls cron endpoints (demo, GBP, insights, batch). Set CRON_TARGET_URL (vars) and CRON_SECRET (secret).
  * - Website Template: pings health endpoint to keep the service warm. Set WEBSITE_TEMPLATE_URL (vars, optional).
+ * - Stitch (Render): pings GET /api/health to keep the service warm. Set STITCH_URL (vars, optional).
  *
  * One Cron Trigger (every minute) plus UTC minute modulo matches separate 1/2/3/5/14 minute schedules
  * and stays under the Free tier cap of 5 Cron Triggers per account (see Cloudflare Workers limits).
@@ -13,6 +14,8 @@ export interface Env {
 	CRON_SECRET: string;
 	CRON_TARGET_URL: string;
 	WEBSITE_TEMPLATE_URL?: string;
+	/** Base URL for Stitch on Render (GET /api/health). */
+	STITCH_URL?: string;
 }
 
 /** Avoid http→https redirects: fetch may drop Authorization on redirect, so cron gets 401. */
@@ -92,6 +95,12 @@ export default {
 			);
 			const r = await pingHealth(`${websiteTemplateBase}/api/health`);
 			console.log(`[cron-worker] website-template: ${r.status} ${r.ok ? "ok" : r.text}`);
+
+			const stitchBase = normalizeCronBase((env.STITCH_URL ?? "https://stitch-svw5.onrender.com").trim());
+			if (stitchBase) {
+				const rStitch = await pingHealth(`${stitchBase}/api/health`);
+				console.log(`[cron-worker] stitch: ${rStitch.status} ${rStitch.ok ? "ok" : rStitch.text.slice(0, 200)}`);
+			}
 		}
 	},
 };

--- a/apps/cron-worker/wrangler.toml
+++ b/apps/cron-worker/wrangler.toml
@@ -4,10 +4,12 @@ compatibility_date = "2024-01-01"
 
 # Admin app: set CRON_TARGET_URL and CRON_SECRET (secret).
 # Website Template: set WEBSITE_TEMPLATE_URL to ping GET /api/health (keeps service warm).
+# Stitch (Render): set STITCH_URL to ping GET /api/health (keeps service warm).
 [vars]
 CRON_TARGET_URL = "https://admin.ednsy.com"
 # Website Template base URL (GET /api/health), no trailing slash.
 WEBSITE_TEMPLATE_URL = "https://website-template-68wq.onrender.com"
+STITCH_URL = "https://stitch-svw5.onrender.com"
 
 [triggers]
 # Single trigger to stay within Cloudflare Free "Cron Triggers per account" (5). Handler runs every minute and

--- a/apps/stitch/app/api/health/route.ts
+++ b/apps/stitch/app/api/health/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from "next/server";
+
+/**
+ * GET /api/health — liveness for uptime monitors and cron warm pings (no auth).
+ */
+export async function GET() {
+  return NextResponse.json({ ok: true, service: "stitch" });
+}


### PR DESCRIPTION
## Summary

This PR delivers the Stitch async demo flow and admin integration, plus a Cloudflare cron warm ping for the Stitch Render app and a `GET /api/health` endpoint.

### Stitch + admin (existing commits on branch)

- Async demo generator and admin integration (see branch history).

### Cron + health (closes #68)

- **Cloudflare cron worker:** `STITCH_URL` binding; pings `GET /api/health` every 14 minutes (same UTC cadence as website template).
- **Stitch app:** `GET /api/health` returns JSON `{ ok: true, service: "stitch" }` for monitors and cron.

## Deploy notes

- Deploy Stitch so `/api/health` exists, then redeploy the cron worker (`wrangler deploy`).

Closes #68
