### PR TITLE
feat(admin): outreach email review dialog and draft overrides

### DIFF
--- a/apps/admin/src/lib/server/crmOutreachGmail.ts
+++ b/apps/admin/src/lib/server/crmOutreachGmail.ts
@@ -16,6 +16,42 @@ import {
 import { getEffectiveEmailSenderName } from '$lib/server/userSettings';
 import { prepareCrmOutreachEmail, type CrmOutreachKind } from '$lib/server/crmOutreachEmail';
 
+const OUTREACH_DRAFT_MAX_SUBJECT_CHARS = 500;
+const OUTREACH_DRAFT_MAX_HTML_CHARS = 2_000_000;
+
+/**
+ * Optional subject + HTML from the review dialog. When omitted (e.g. bulk draft create), content is generated server-side only.
+ */
+export function parseOutreachDraftOverridesFromForm(formData: FormData):
+	| { ok: true; overrides: { subject: string; html: string } }
+	| { ok: true; overrides: undefined }
+	| { ok: false; error: string } {
+	if (!formData.has('outreachSubject') && !formData.has('outreachHtml')) {
+		return { ok: true, overrides: undefined };
+	}
+	if (!formData.has('outreachSubject') || !formData.has('outreachHtml')) {
+		return { ok: false, error: 'Invalid outreach form.' };
+	}
+	const subject = String(formData.get('outreachSubject') ?? '').trim();
+	const html = String(formData.get('outreachHtml') ?? '').trim();
+	if (!subject) {
+		return { ok: false, error: 'Subject cannot be empty.' };
+	}
+	if (!html) {
+		return { ok: false, error: 'Email body cannot be empty.' };
+	}
+	if (subject.length > OUTREACH_DRAFT_MAX_SUBJECT_CHARS) {
+		return {
+			ok: false,
+			error: `Subject must be at most ${OUTREACH_DRAFT_MAX_SUBJECT_CHARS} characters.`
+		};
+	}
+	if (html.length > OUTREACH_DRAFT_MAX_HTML_CHARS) {
+		return { ok: false, error: 'Email body is too large.' };
+	}
+	return { ok: true, overrides: { subject, html } };
+}
+
 export async function executeCreateGmailOutreachDraft(params: {
 	userId: string;
 	appUserEmail: string | null;
@@ -25,6 +61,8 @@ export async function executeCreateGmailOutreachDraft(params: {
 	linkOrigin: string;
 	/** When true, set demo_tracking to email_draft after success (demo outreach only). */
 	setDemoTrackingEmailDraft: boolean;
+	/** From review dialog: user-edited subject and HTML body. */
+	draftOverrides?: { subject: string; html: string };
 }): Promise<{ ok: true; draftId: string } | { ok: false; error: string }> {
 	const {
 		userId,
@@ -33,7 +71,8 @@ export async function executeCreateGmailOutreachDraft(params: {
 		prospectId,
 		kind,
 		linkOrigin,
-		setDemoTrackingEmailDraft
+		setDemoTrackingEmailDraft,
+		draftOverrides
 	} = params;
 
 	const prepared = await prepareCrmOutreachEmail({
@@ -45,6 +84,9 @@ export async function executeCreateGmailOutreachDraft(params: {
 	});
 	if (!prepared.ok) return { ok: false, error: prepared.error };
 
+	const subject = draftOverrides?.subject ?? prepared.subject;
+	const html = draftOverrides?.html ?? prepared.html;
+
 	const fromName = await getEffectiveEmailSenderName(userId, appUserEmail);
 
 	const existingDraft = prospect.gmailOutreachDraftId?.trim();
@@ -55,8 +97,8 @@ export async function executeCreateGmailOutreachDraft(params: {
 	const draftRes = await createDraftViaGmail(
 		userId,
 		prepared.effectiveTo,
-		prepared.subject,
-		prepared.html,
+		subject,
+		html,
 		fromName
 	);
 	if (!draftRes.ok) return { ok: false, error: draftRes.error };
@@ -73,7 +115,7 @@ export async function executeCreateGmailOutreachDraft(params: {
 	}
 
 	await recordDemoEvent(prospectId, GMAIL_OUTREACH_EVENT_DRAFT_CREATED, {
-		subject: prepared.subject,
+		subject,
 		kind,
 		gmailDraftId: draftRes.draftId,
 		...(draftRes.messageId ? { gmailMessageId: draftRes.messageId } : {})

--- a/apps/admin/src/lib/server/generateEmailCopy.ts
+++ b/apps/admin/src/lib/server/generateEmailCopy.ts
@@ -1,7 +1,7 @@
 import { env } from '$env/dynamic/private';
 import type { Prospect } from '$lib/server/prospects';
 import { getResolvedContent } from '$lib/server/agentContent';
-import { serverError } from '$lib/server/logger';
+import { serverError, serverInfo } from '$lib/server/logger';
 
 const GEMINI_API_KEY = env.GEMINI_API_KEY;
 const GEMINI_MODEL = 'gemini-2.5-flash';
@@ -87,6 +87,28 @@ function repairJsonNewlines(raw: string): string {
 	// If still inside a string (unterminated), close it and the object so parse can succeed
 	if (inString) result += '"}';
 	return result;
+}
+
+/**
+ * When JSON is truncated or malformed, try to pull subjectLine / openingHook with regex.
+ */
+function extractEmailCopyFieldsLoose(raw: string): { openingHook?: string; subjectLine?: string } {
+	const out: { openingHook?: string; subjectLine?: string } = {};
+	const pick = (key: 'subjectLine' | 'openingHook') => {
+		const re = new RegExp(`"${key}"\\s*:\\s*"((?:[^"\\\\]|\\\\.)*)`, 's');
+		const m = raw.match(re);
+		if (!m?.[1]) return;
+		const unescaped = m[1]
+			.replace(/\\n/g, '\n')
+			.replace(/\\r/g, '\r')
+			.replace(/\\"/g, '"')
+			.replace(/\\\\/g, '\\');
+		const t = unescaped.trim();
+		if (t) out[key] = t;
+	};
+	pick('subjectLine');
+	pick('openingHook');
+	return out;
 }
 
 /** Accept common field variants Gemini may return for the opening paragraph and subject line. */
@@ -243,7 +265,8 @@ export async function generateEmailCopy(
 			body: JSON.stringify({
 				contents: [{ role: 'user', parts: [{ text: prompt }] }],
 				generationConfig: {
-					maxOutputTokens: 512,
+					/** Short JSON; 1024 avoids rare MAX_TOKENS truncation mid-object ("Unexpected end of JSON input"). */
+					maxOutputTokens: 1024,
 					temperature: 0.7,
 					responseMimeType: 'application/json'
 				}
@@ -258,12 +281,26 @@ export async function generateEmailCopy(
 		}
 
 		const data = (await res.json()) as {
-			candidates?: { content?: { parts?: { text?: string }[] } }[];
+			candidates?: {
+				content?: { parts?: { text?: string }[] };
+				finishReason?: string;
+			}[];
 		};
-		const text = data.candidates?.[0]?.content?.parts?.[0]?.text?.trim();
-		if (!text) return { copy: null, promptSource: resolved.source, error: 'Gemini returned empty content' };
+		const candidate0 = data.candidates?.[0];
+		const finishReason = candidate0?.finishReason;
+		const text = candidate0?.content?.parts?.[0]?.text?.trim();
+		if (!text) {
+			serverError('generateEmailCopy', 'Gemini empty content', {
+				finishReason: finishReason ?? 'unknown'
+			});
+			return { copy: null, promptSource: resolved.source, error: 'Gemini returned empty content' };
+		}
 
 		const raw = text.replace(/^```json\s*/i, '').replace(/\s*```$/i, '').trim();
+		if (!raw) {
+			return { copy: null, promptSource: resolved.source, error: 'Gemini returned empty JSON text' };
+		}
+
 		let parsed: unknown;
 		try {
 			parsed = JSON.parse(raw);
@@ -272,11 +309,27 @@ export async function generateEmailCopy(
 			if (parseErr instanceof SyntaxError) {
 				try {
 					parsed = JSON.parse(repairJsonNewlines(raw));
-				} catch {
-					serverError('generateEmailCopy', 'JSON parse failed after repair', {
-						message: parseErr instanceof Error ? parseErr.message : String(parseErr)
-					});
-					return { copy: null, promptSource: resolved.source, error: 'Could not parse Gemini JSON response' };
+				} catch (parseErr2) {
+					const loose = extractEmailCopyFieldsLoose(raw);
+					if (loose.subjectLine || loose.openingHook) {
+						parsed = loose;
+						if (finishReason && finishReason !== 'STOP') {
+							serverInfo('generateEmailCopy', 'Used loose JSON extraction', {
+								finishReason,
+								hadSubject: !!loose.subjectLine,
+								hadHook: !!loose.openingHook
+							});
+						}
+					} else {
+						serverError('generateEmailCopy', 'JSON parse failed after repair', {
+							first: parseErr instanceof Error ? parseErr.message : String(parseErr),
+							second: parseErr2 instanceof Error ? parseErr2.message : String(parseErr2),
+							finishReason: finishReason ?? 'unknown',
+							rawLen: raw.length,
+							rawHead: raw.slice(0, 120)
+						});
+						return { copy: null, promptSource: resolved.source, error: 'Could not parse Gemini JSON response' };
+					}
 				}
 			} else {
 				throw parseErr;

--- a/apps/admin/src/routes/dashboard/prospects/[id]/+page.server.ts
+++ b/apps/admin/src/routes/dashboard/prospects/[id]/+page.server.ts
@@ -32,7 +32,8 @@ import { deleteProspect, updateProspectContact } from '$lib/server/prospects';
 import { prepareCrmOutreachEmail, type CrmOutreachKind } from '$lib/server/crmOutreachEmail';
 import {
 	executeCreateGmailOutreachDraft,
-	executeSendGmailOutreachDraft
+	executeSendGmailOutreachDraft,
+	parseOutreachDraftOverridesFromForm
 } from '$lib/server/crmOutreachGmail';
 import { DEV_OUTBOUND_EMAIL } from '$lib/constants';
 
@@ -374,6 +375,12 @@ export const actions: Actions = {
 			return fail(400, { message: 'No email to send to.' });
 		}
 
+		const overridesParsed = parseOutreachDraftOverridesFromForm(formData);
+		if (!overridesParsed.ok) {
+			return fail(400, { message: overridesParsed.error });
+		}
+		const draftOverrides = overridesParsed.overrides;
+
 		let sent = 0;
 		if (prospect.email?.trim()) {
 			const ex = await executeCreateGmailOutreachDraft({
@@ -383,7 +390,8 @@ export const actions: Actions = {
 				prospectId,
 				kind,
 				linkOrigin,
-				setDemoTrackingEmailDraft: kind === 'demo' && !!demoTracking
+				setDemoTrackingEmailDraft: kind === 'demo' && !!demoTracking,
+				...(draftOverrides ? { draftOverrides } : {})
 			});
 			if (!ex.ok) return fail(502, { message: ex.error });
 			sent++;

--- a/apps/admin/src/routes/dashboard/prospects/[id]/+page.svelte
+++ b/apps/admin/src/routes/dashboard/prospects/[id]/+page.svelte
@@ -31,6 +31,7 @@
 	import * as Dialog from '$lib/components/ui/dialog';
 	import { Label } from '$lib/components/ui/label';
 	import { Input } from '$lib/components/ui/input';
+	import { Textarea } from '$lib/components/ui/textarea';
 	import * as Select from '$lib/components/ui/select';
 	import { cn } from '$lib/utils';
 	import { normalizeExternalHref } from '$lib/externalUrl';
@@ -102,6 +103,8 @@
 	let previewLoading = $state(false);
 	let previewError = $state('');
 	let previewFormEl = $state<HTMLFormElement | null>(null);
+	/** Outreach dialog: switch between raw HTML and rendered preview */
+	let outreachBodyView = $state<'source' | 'preview'>('source');
 	let creatingDraft = $state(false);
 	let sendingDraft = $state(false);
 	let sendDraftConfirmOpen = $state(false);
@@ -128,6 +131,7 @@
 
 	async function openOutreachDialog(kind: 'demo' | 'alternate') {
 		currentOutreachKind = kind;
+		outreachBodyView = 'source';
 		previewSubject = '';
 		previewHtml = '';
 		previewTo = '';
@@ -879,14 +883,18 @@
 	</header>
 
 	<Dialog.Root bind:open={outreachDialogOpen}>
-		<Dialog.Content class="max-w-3xl max-h-[90vh] flex flex-col gap-0 sm:max-w-3xl">
-			<Dialog.Header>
+		<Dialog.Content
+			class="max-w-[calc(100vw-2rem)] max-h-[min(90dvh,900px)] w-[min(100%,48rem)] flex min-h-0 flex-col gap-0 sm:max-w-3xl"
+		>
+			<Dialog.Header class="shrink-0 pr-6">
 				<Dialog.Title>Review outreach email</Dialog.Title>
 				<Dialog.Description>
-					Preview the message, then create a draft in your Gmail. Reconnect Gmail in Integrations if draft creation fails (OAuth needs gmail.compose).
+					Edit the subject and body if you want; use Preview to see how it renders. Then create a draft in your Gmail. Reconnect Gmail in Integrations if draft creation fails (OAuth needs gmail.compose).
 				</Dialog.Description>
 			</Dialog.Header>
-			<div class="min-h-0 flex flex-col gap-3 py-2 overflow-hidden">
+			<div
+				class="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto overflow-x-hidden overscroll-contain pt-2 [scrollbar-gutter:stable]"
+			>
 				{#if previewLoading}
 					<div class="flex items-center gap-2 text-sm text-muted-foreground py-8 justify-center">
 						<LoaderCircle class="size-5 animate-spin" aria-hidden="true" />
@@ -895,23 +903,77 @@
 				{:else if previewError}
 					<p class="text-sm text-destructive">{previewError}</p>
 				{:else if previewHtml}
-					<div class="space-y-2 text-sm shrink-0">
-						<p><span class="text-muted-foreground">To:</span> {previewTo}</p>
-						<p><span class="text-muted-foreground">Subject:</span> {previewSubject}</p>
+					<p class="text-sm shrink-0">
+						<span class="text-muted-foreground">To:</span>
+						{previewTo}
+					</p>
+					<div class="space-y-2 shrink-0">
+						<Label for="outreach-subject-{prospect.id}">Subject</Label>
+						<Input
+							id="outreach-subject-{prospect.id}"
+							name="outreachSubject"
+							form={createGmailDraftFormId}
+							bind:value={previewSubject}
+							autocomplete="off"
+							class="w-full"
+						/>
 					</div>
-					<div class="border rounded-md min-h-[200px] max-h-[50vh] overflow-auto bg-muted/30">
-						<iframe
-							class="w-full min-h-[240px] border-0 bg-background"
-							title="Email preview"
-							srcdoc={previewHtml}
-							sandbox="allow-same-origin"
-						></iframe>
+					<div class="flex min-h-0 flex-col gap-2">
+						<div class="flex shrink-0 items-center justify-between gap-3">
+							<Label for="outreach-html-{prospect.id}" class="mb-0">Body</Label>
+							<div
+								class="inline-flex shrink-0 rounded-md border bg-muted/40 p-0.5"
+								role="group"
+								aria-label="Body source or preview"
+							>
+								<Button
+									type="button"
+									size="sm"
+									variant={outreachBodyView === 'source' ? 'secondary' : 'ghost'}
+									class="h-7 rounded-sm px-2.5 text-xs"
+									aria-pressed={outreachBodyView === 'source'}
+									onclick={() => (outreachBodyView = 'source')}
+								>
+									Source
+								</Button>
+								<Button
+									type="button"
+									size="sm"
+									variant={outreachBodyView === 'preview' ? 'secondary' : 'ghost'}
+									class="h-7 rounded-sm px-2.5 text-xs"
+									aria-pressed={outreachBodyView === 'preview'}
+									onclick={() => (outreachBodyView = 'preview')}
+								>
+									Preview
+								</Button>
+							</div>
+						</div>
+						<div class="pb-4">
+							{#if outreachBodyView === 'source'}
+								<Textarea
+									id="outreach-html-{prospect.id}"
+									name="outreachHtml"
+									form={createGmailDraftFormId}
+									bind:value={previewHtml}
+									class="field-sizing-fixed box-border w-full min-h-[12rem] max-h-[min(42dvh,20rem)] font-mono text-xs leading-relaxed sm:min-h-[14rem] sm:max-h-[min(48dvh,24rem)] sm:text-sm md:max-h-[min(52dvh,28rem)] pb-4"
+									spellcheck={false}
+								/>
+							{:else}
+								<input type="hidden" name="outreachHtml" form={createGmailDraftFormId} value={previewHtml} />
+								<iframe
+									class="box-border block w-full min-h-[12rem] max-h-[min(42dvh,20rem)] rounded-md border border-border bg-background sm:min-h-[14rem] sm:max-h-[min(48dvh,24rem)] md:max-h-[min(52dvh,28rem)]"
+									title="Email preview"
+									srcdoc={previewHtml}
+									sandbox="allow-same-origin"
+								></iframe>
+							{/if}
+						</div>
 					</div>
 				{:else}
 					<p class="text-sm text-muted-foreground py-4">Open this dialog again to load a preview.</p>
 				{/if}
 			</div>
-			<Dialog.Footer class="gap-2 sm:gap-2 flex-col sm:flex-row sm:justify-end">
+			<Dialog.Footer class="shrink-0 gap-2 sm:gap-2 flex-col sm:flex-row sm:justify-end">
 				<Button type="button" variant="outline" onclick={() => (outreachDialogOpen = false)}>Cancel</Button>
 				{#if !gmailConnected}
 					<Button href={integrationsGmailHref}>
@@ -950,7 +1012,12 @@
 						<input type="hidden" name="outreachKind" value={currentOutreachKind} />
 						<Button
 							type="submit"
-							disabled={creatingDraft || previewLoading || !!previewError || !previewHtml || !canSend}
+							disabled={creatingDraft ||
+								previewLoading ||
+								!!previewError ||
+								!previewHtml ||
+								!previewSubject.trim() ||
+								!canSend}
 						>
 							{#if creatingDraft}<LoaderCircle class="size-4 mr-2 animate-spin" aria-hidden="true" />{/if}
 							{creatingDraft ? 'Creating…' : 'Create draft in Gmail'}


### PR DESCRIPTION
Closes #70

## Summary
Improves the **Review outreach email** flow on the prospect detail page and makes Gmail draft creation use edited subject/body. Harden **generateEmailCopy** against empty or malformed Gemini JSON.

## Changes
### UI (\prospects/[id]/+page.svelte\)
- Editable **Subject** and **Body**; **Source** / **Preview** toggle; submitted values used when creating a draft
- Scrollable dialog body with **flex-1 min-h-0 overflow-y-auto** so content is not clipped by the footer
- Responsive dialog shell and body field sizing (\dvh\ / \svh\ where appropriate)

### Server
- **crmOutreachGmail.ts**: \parseOutreachDraftOverridesFromForm\, optional \draftOverrides\ in \xecuteCreateGmailOutreachDraft\
- **prospects/[id]/+page.server.ts**: read overrides on \createGmailOutreachDraft\ (bulk flows unchanged when fields absent)
- **generateEmailCopy.ts**: guards, repair + loose extraction fallback, \maxOutputTokens\ 1024, improved logging

## Testing
- [ ] Open prospect with approved demo + email: review dialog loads, edit subject/body, create draft → Gmail shows edits
- [ ] Bulk draft creation still works without override fields

Made with [Cursor](https://cursor.com)