### PR TITLE
fix(admin): AI Agents freeze + Email settings Svelte warnings

### DIFF
--- a/apps/admin/src/routes/dashboard/agents/+page.svelte
+++ b/apps/admin/src/routes/dashboard/agents/+page.svelte
@@ -6,6 +6,7 @@
 	import { Label } from '$lib/components/ui/label';
 	import { Textarea } from '$lib/components/ui/textarea';
 	import { Badge } from '$lib/components/ui/badge';
+	import { untrack } from 'svelte';
 	import { toastSuccess, toastError } from '$lib/toast';
 	import type { ContentSlot } from './+page.server';
 
@@ -53,10 +54,8 @@
 	$effect(() => {
 		const slots = data.slots ?? [];
 		if (slots.length === 0) return;
-		editingBodies = {
-			...editingBodies,
-			...Object.fromEntries(slots.map((s: ContentSlot) => [slotKey(s), s.body]))
-		};
+		const fromServer = Object.fromEntries(slots.map((s: ContentSlot) => [slotKey(s), s.body]));
+		editingBodies = { ...untrack(() => editingBodies), ...fromServer };
 	});
 
 	$effect(() => {

--- a/apps/admin/src/routes/dashboard/settings/email/+page.svelte
+++ b/apps/admin/src/routes/dashboard/settings/email/+page.svelte
@@ -10,10 +10,10 @@
 
 	let { data } = $props<{ data: PageData }>();
 
-	let senderName = $state(data.emailSenderName ?? '');
-	let emailSignatureOverride = $state(data.emailSignatureOverride ?? '');
+	let senderName = $state('');
+	let emailSignatureOverride = $state('');
 
-	$effect(() => {
+	$effect.pre(() => {
 		senderName = data.emailSenderName ?? '';
 		emailSignatureOverride = data.emailSignatureOverride ?? '';
 	});


### PR DESCRIPTION
## Summary

Closes #76.

- **AI Agents** (`/dashboard/agents`): Fixed an infinite `$effect` loop by reading the previous `editingBodies` map inside `untrack()`, so the effect only reacts to `data.slots`. This restores responsive sidebar navigation after visiting the page.
- **Email settings**: Initialized form state with empty strings and synced from `data` in `$effect.pre`, consistent with General settings, removing `state_referenced_locally` Vite warnings.

## Test plan

- [ ] Open AI Agents, then Dashboard / Prospects / Integrations / Settings without refresh.
- [ ] Run dev server; confirm no `state_referenced_locally` warnings for `settings/email/+page.svelte`.
