### PR TITLE
fix(admin): shared workspace prospect list and detail

### DIFF
--- a/apps/admin/src/lib/server/prospects.ts
+++ b/apps/admin/src/lib/server/prospects.ts
@@ -97,7 +97,8 @@ export async function listProspects(): Promise<ListProspectsResult> {
 		.select(
 			'id, company_name, email, website, phone, industry, status, demo_link, provider, provider_row_id, user_id, address, flagged, flagged_reason'
 		)
-		.order('updated_at', { ascending: false });
+		.order('updated_at', { ascending: false })
+		.limit(5000);
 	if (error) return { prospects: [], error: 'api_error', message: error.message };
 	const prospects = (data ?? []).map((r) => rowToProspect(r));
 	return { prospects };
@@ -115,7 +116,8 @@ export async function listProspectsForUser(userId: string): Promise<ListProspect
 			'id, company_name, email, website, phone, industry, status, demo_link, provider, provider_row_id, user_id, address, flagged, flagged_reason'
 		)
 		.eq('user_id', userId)
-		.order('updated_at', { ascending: false });
+		.order('updated_at', { ascending: false })
+		.limit(5000);
 	if (error) return { prospects: [], error: 'api_error', message: error.message };
 	const prospects = (data ?? []).map((r) => rowToProspect(r));
 	return { prospects };

--- a/apps/admin/src/lib/server/supabase.ts
+++ b/apps/admin/src/lib/server/supabase.ts
@@ -315,6 +315,37 @@ export async function getDemoTrackingForProspect(
 }
 
 /**
+ * Latest demo_tracking row for a prospect (any owner). For shared staff detail page.
+ */
+export async function getDemoTrackingForProspectLatest(prospectId: string): Promise<{
+	status: string;
+	send_time: string | null;
+	opened_at: string | null;
+	clicked_at: string | null;
+	created_at: string;
+	updated_at: string;
+} | null> {
+	const supabase = getSupabaseAdmin();
+	if (!supabase) return null;
+	const { data, error } = await supabase
+		.from('demo_tracking')
+		.select('status, send_time, opened_at, clicked_at, created_at, updated_at')
+		.eq('prospect_id', prospectId)
+		.order('updated_at', { ascending: false })
+		.limit(1)
+		.maybeSingle();
+	if (error || !data) return null;
+	return {
+		status: data.status ?? 'draft',
+		send_time: data.send_time ?? null,
+		opened_at: data.opened_at ?? null,
+		clicked_at: data.clicked_at ?? null,
+		created_at: data.created_at ?? data.updated_at ?? new Date().toISOString(),
+		updated_at: data.updated_at ?? new Date().toISOString()
+	};
+}
+
+/**
  * Fetch prospect_id -> scraped_data for all prospects that have scraped_data (for list/dashboard).
  * Uses latest row per prospect when multiple demo_tracking rows exist.
  */
@@ -327,6 +358,29 @@ export async function getScrapedDataMapForUser(
 		.from('demo_tracking')
 		.select('prospect_id, scraped_data')
 		.eq('user_id', userId)
+		.not('prospect_id', 'is', null)
+		.not('scraped_data', 'is', null)
+		.order('updated_at', { ascending: false });
+	if (error || !data?.length) return {};
+	const map: Record<string, Record<string, unknown>> = {};
+	for (const row of data) {
+		const pid = row.prospect_id;
+		if (pid && !(pid in map) && row.scraped_data) {
+			map[pid] = row.scraped_data as Record<string, unknown>;
+		}
+	}
+	return map;
+}
+
+/**
+ * Global scraped_data map (any owner). Latest `updated_at` wins per prospect_id.
+ */
+export async function getScrapedDataMapGlobal(): Promise<Record<string, Record<string, unknown>>> {
+	const supabase = getSupabaseAdmin();
+	if (!supabase) return {};
+	const { data, error } = await supabase
+		.from('demo_tracking')
+		.select('prospect_id, scraped_data')
 		.not('prospect_id', 'is', null)
 		.not('scraped_data', 'is', null)
 		.order('updated_at', { ascending: false });
@@ -434,6 +488,68 @@ export async function getDemoJobsForUser(
 		}
 	}
 	return map;
+}
+
+/**
+ * Latest demo job per prospect (any owner). For shared staff workspace list/detail.
+ */
+export async function getDemoJobsMapGlobal(): Promise<
+	Record<string, { status: DemoJobStatus; jobId: string; demoLink?: string | null; errorMessage?: string | null }>
+> {
+	const supabase = getSupabaseAdmin();
+	if (!supabase) return {};
+	const { data, error } = await supabase
+		.from('demo_jobs')
+		.select('id, prospect_id, status, demo_link, error_message')
+		.in('status', ['pending', 'creating', 'done', 'failed'])
+		.order('created_at', { ascending: false });
+	if (error || !data?.length) return {};
+	const map: Record<
+		string,
+		{ status: DemoJobStatus; jobId: string; demoLink?: string | null; errorMessage?: string | null }
+	> = {};
+	for (const row of data) {
+		const pid = row.prospect_id;
+		if (pid && !(pid in map)) {
+			map[pid] = {
+				status: row.status as DemoJobStatus,
+				jobId: row.id,
+				demoLink: row.demo_link ?? undefined,
+				errorMessage: row.error_message ?? undefined
+			};
+		}
+	}
+	return map;
+}
+
+/**
+ * Latest demo_jobs row for a prospect (any owner), same statuses as list UI.
+ */
+export async function getLatestDemoJobForProspect(
+	prospectId: string
+): Promise<{
+	status: DemoJobStatus;
+	jobId: string;
+	demoLink?: string | null;
+	errorMessage?: string | null;
+} | null> {
+	const supabase = getSupabaseAdmin();
+	if (!supabase) return null;
+	const { data, error } = await supabase
+		.from('demo_jobs')
+		.select('id, status, demo_link, error_message')
+		.eq('prospect_id', prospectId)
+		.in('status', ['pending', 'creating', 'done', 'failed'])
+		.order('created_at', { ascending: false })
+		.limit(1)
+		.maybeSingle();
+	if (error || !data?.id) return null;
+	return {
+		status: data.status as DemoJobStatus,
+		jobId: data.id as string,
+		demoLink: data.demo_link ?? undefined,
+		errorMessage: data.error_message ?? undefined
+	};
 }
 
 /**
@@ -615,6 +731,24 @@ export async function getGbpJobsForUser(
 		.from('gbp_jobs')
 		.select('id, prospect_id, status')
 		.eq('user_id', userId)
+		.in('status', ['pending', 'running'])
+		.order('created_at', { ascending: false });
+	if (error || !data?.length) return {};
+	const map: Record<string, { jobId: string; status: GbpJobStatus }> = {};
+	for (const row of data) {
+		const pid = row.prospect_id as string;
+		if (pid && !(pid in map)) map[pid] = { jobId: row.id as string, status: row.status as GbpJobStatus };
+	}
+	return map;
+}
+
+/** Map of prospect_id -> latest active (pending/running) GBP job (any owner). */
+export async function getGbpJobsMapGlobal(): Promise<Record<string, { jobId: string; status: GbpJobStatus }>> {
+	const supabase = getSupabaseAdmin();
+	if (!supabase) return {};
+	const { data, error } = await supabase
+		.from('gbp_jobs')
+		.select('id, prospect_id, status')
 		.in('status', ['pending', 'running'])
 		.order('created_at', { ascending: false });
 	if (error || !data?.length) return {};
@@ -878,6 +1012,26 @@ export async function getInsightsJobsForUser(
 		.from('insights_jobs')
 		.select('id, prospect_id, status')
 		.eq('user_id', userId)
+		.in('status', ['pending', 'running'])
+		.order('created_at', { ascending: false });
+	if (error || !data?.length) return {};
+	const map: Record<string, { jobId: string; status: InsightsJobStatus }> = {};
+	for (const row of data) {
+		const pid = row.prospect_id as string;
+		if (pid && !(pid in map)) map[pid] = { jobId: row.id as string, status: row.status as InsightsJobStatus };
+	}
+	return map;
+}
+
+/** Map of prospect_id -> latest active (pending/running) Insights job (any owner). */
+export async function getInsightsJobsMapGlobal(): Promise<
+	Record<string, { jobId: string; status: InsightsJobStatus }>
+> {
+	const supabase = getSupabaseAdmin();
+	if (!supabase) return {};
+	const { data, error } = await supabase
+		.from('insights_jobs')
+		.select('id, prospect_id, status')
 		.in('status', ['pending', 'running'])
 		.order('created_at', { ascending: false });
 	if (error || !data?.length) return {};

--- a/apps/admin/src/routes/dashboard/+page.server.ts
+++ b/apps/admin/src/routes/dashboard/+page.server.ts
@@ -1,6 +1,6 @@
 import { fail, redirect } from '@sveltejs/kit';
 import {
-	listProspectsForUser,
+	listProspects,
 	getProspectById,
 	updateProspectDemoLink,
 	updateProspectFromGbp,
@@ -37,7 +37,7 @@ export const load: PageServerLoad = async (event) => {
 			getGbpCountThisMonth(user.id),
 			getInsightsCountThisMonth(user.id),
 			getPlacesCountThisMonth(),
-			listProspectsForUser(user.id)
+			listProspects()
 		]);
 	const placesMonthlyLimit = getPlacesMonthlyLimit();
 	const prospects = prospectsResult.prospects ?? [];

--- a/apps/admin/src/routes/dashboard/prospects/+page.server.ts
+++ b/apps/admin/src/routes/dashboard/prospects/+page.server.ts
@@ -1,7 +1,6 @@
 import { fail, redirect } from '@sveltejs/kit';
 import {
 	listProspects,
-	listProspectsForUser,
 	getProspectById,
 	updateProspectDemoLink,
 	updateProspectFromGbp,
@@ -11,20 +10,20 @@ import {
 } from '$lib/server/prospects';
 import {
 	getSupabaseAdmin,
-	getDemoTrackingForUser,
+	getDemoTrackingMapGlobal,
 	getDemoTrackingForProspect,
 	getDemoCountThisMonth,
 	updateDemoTrackingStatus,
 	upsertDemoTrackingForProspect,
-	getScrapedDataMapForUser,
+	getScrapedDataMapGlobal,
 	getScrapedDataForProspectForUser,
 	enqueueDemoJob,
 	enqueueGbpJob,
 	enqueueInsightsJob,
-	getDemoJobsForUser,
+	getDemoJobsMapGlobal,
 	getActiveDemoJobForProspect,
-	getGbpJobsForUser,
-	getInsightsJobsForUser,
+	getGbpJobsMapGlobal,
+	getInsightsJobsMapGlobal,
 	getGbpJobForProspect,
 	getInsightsJobForProspect
 } from '$lib/server/supabase';
@@ -75,15 +74,15 @@ export const load: PageServerLoad = async (event) => {
 		throw redirect(303, '/auth/login');
 	}
 	const demoCountThisMonth = await getDemoCountThisMonth(user.id);
-	const result = await listProspectsForUser(user.id);
+	const result = await listProspects();
 	const prospects = result.prospects ?? [];
-	const demoTrackingByProspectId = await getDemoTrackingForUser(user.id);
-	const scrapedDataByProspectId = await getScrapedDataMapForUser(user.id);
-	const demoJobsByProspectId = await getDemoJobsForUser(user.id);
+	const demoTrackingByProspectId = await getDemoTrackingMapGlobal();
+	const scrapedDataByProspectId = await getScrapedDataMapGlobal();
+	const demoJobsByProspectId = await getDemoJobsMapGlobal();
 	const hasDemoCreatingJob = Object.values(demoJobsByProspectId).some((j) => j.status === 'creating');
 	const [gbpJobsByProspectId, insightsJobsByProspectId] = await Promise.all([
-		getGbpJobsForUser(user.id),
-		getInsightsJobsForUser(user.id)
+		getGbpJobsMapGlobal(),
+		getInsightsJobsMapGlobal()
 	]);
 	const sendConfigured = await getSendConfigured(user.id);
 	const { todayCount: gbpDentalTodayCount, dailyCap: gbpDentalDailyCap } =
@@ -400,7 +399,7 @@ export const actions: Actions = {
 		if (prospectIds.length === 0) {
 			return fail(400, { message: 'Select at least one prospect' });
 		}
-		const scrapedMap = await getScrapedDataMapForUser(user.id);
+		const scrapedMap = await getScrapedDataMapGlobal();
 		let queued = 0;
 		const errors: string[] = [];
 		for (const prospectId of prospectIds) {
@@ -718,7 +717,7 @@ export const actions: Actions = {
 		}
 
 		// Demo queue (create + retry); only enqueue prospects that have GBP data
-		const scrapedMap = await getScrapedDataMapForUser(user.id);
+		const scrapedMap = await getScrapedDataMapGlobal();
 		let demoQueued = 0;
 		const demoErrors: string[] = [];
 		for (const prospectId of demoIds) {
@@ -762,12 +761,12 @@ export const actions: Actions = {
 		const { cookies } = event;
 		const user = await getDashboardSessionUser(event);
 		if (!user) return fail(401, { message: 'Sign in required' });
-		const result = await listProspectsForUser(user.id);
+		const result = await listProspects();
 		const prospects = result.prospects ?? [];
 		const [demoJobsByProspectId, gbpJobsByProspectId, insightsJobsByProspectId] = await Promise.all([
-			getDemoJobsForUser(user.id),
-			getGbpJobsForUser(user.id),
-			getInsightsJobsForUser(user.id)
+			getDemoJobsMapGlobal(),
+			getGbpJobsMapGlobal(),
+			getInsightsJobsMapGlobal()
 		]);
 		let cleared = 0;
 		for (const p of prospects) {

--- a/apps/admin/src/routes/dashboard/prospects/[id]/+page.server.ts
+++ b/apps/admin/src/routes/dashboard/prospects/[id]/+page.server.ts
@@ -1,18 +1,18 @@
 import { fail, redirect } from '@sveltejs/kit';
-import { getProspectByIdForUser } from '$lib/server/prospects';
+import { getProspectByIdWithCreated } from '$lib/server/prospects';
 import {
-	getDemoTrackingForProspect,
+	getDemoTrackingForProspectLatest,
 	getScrapedDataForProspect,
 	getScrapedDataForProspectForUser,
 	updateDemoTrackingStatus,
 	enqueueDemoJob,
-	getDemoJobsForUser,
+	getLatestDemoJobForProspect,
 	upsertDemoTrackingForProspect,
 	getSupabaseAdmin,
 	enqueueInsightsJob,
 	enqueueGbpJob,
-	getInsightsJobForProspect,
-	getGbpJobForProspect,
+	getInsightsJobForProspectLatest,
+	getGbpJobForProspectLatest,
 	getGmailOutreachEventsForProspect
 } from '$lib/server/supabase';
 import type { PageServerLoad, Actions } from './$types';
@@ -40,21 +40,19 @@ export const load: PageServerLoad = async (event) => {
 	if (!user) throw redirect(303, '/auth/login');
 
 	const prospectId = params.id;
-	const prospect = await getProspectByIdForUser(user.id, prospectId);
+	const prospect = await getProspectByIdWithCreated(prospectId);
 	if (!prospect) throw redirect(303, '/dashboard/prospects');
 
-	const [demoTracking, scrapedData, demoJobMap, insightsJob, gbpJob, sendConfigured, gmailOutreachEvents] =
+	const [demoTracking, scrapedData, demoJob, insightsJob, gbpJob, sendConfigured, gmailOutreachEvents] =
 		await Promise.all([
-			getDemoTrackingForProspect(user.id, prospectId),
+			getDemoTrackingForProspectLatest(prospectId),
 			getScrapedDataForProspect(prospectId),
-			getDemoJobsForUser(user.id),
-			getInsightsJobForProspect(user.id, prospectId),
-			getGbpJobForProspect(user.id, prospectId),
+			getLatestDemoJobForProspect(prospectId),
+			getInsightsJobForProspectLatest(prospectId),
+			getGbpJobForProspectLatest(prospectId),
 			getSendConfigured(user.id),
 			getGmailOutreachEventsForProspect(prospectId)
 		]);
-
-	const demoJob = demoJobMap[prospectId] ?? null;
 
 	return {
 		user,
@@ -81,7 +79,7 @@ export const actions: Actions = {
 		if (!prospectId || typeof prospectId !== 'string') {
 			return fail(400, { message: 'Missing prospect ID' });
 		}
-		const prospect = await getProspectByIdForUser(user.id, prospectId);
+		const prospect = await getProspectByIdWithCreated(prospectId);
 		if (!prospect) return fail(404, { message: 'Prospect not found' });
 		if (prospect.flagged && prospect.flaggedReason !== NO_FIT_GBP_REASON) {
 			return fail(400, { message: 'This prospect is out of scope. Analysis is not available.' });
@@ -101,7 +99,7 @@ export const actions: Actions = {
 		if (!prospectId || typeof prospectId !== 'string') {
 			return fail(400, { message: 'Missing prospect ID' });
 		}
-		const prospect = await getProspectByIdForUser(user.id, prospectId);
+		const prospect = await getProspectByIdWithCreated(prospectId);
 		if (!prospect) return fail(404, { message: 'Prospect not found' });
 		if (prospect.flagged && prospect.flaggedReason !== NO_FIT_GBP_REASON) {
 			return fail(400, { message: 'This prospect is out of scope. Regeneration is not available.' });
@@ -120,7 +118,7 @@ export const actions: Actions = {
 		if (!prospectId || typeof prospectId !== 'string') {
 			return fail(400, { message: 'Missing prospect ID' });
 		}
-		const prospect = await getProspectByIdForUser(user.id, prospectId);
+		const prospect = await getProspectByIdWithCreated(prospectId);
 		if (!prospect) return fail(404, { message: 'Prospect not found' });
 		if (prospect.flagged && prospect.flaggedReason !== NO_FIT_GBP_REASON) {
 			return fail(400, { message: 'This prospect is out of scope. Demos and GBP are not available.' });
@@ -177,12 +175,12 @@ export const actions: Actions = {
 		if (!prospectId || typeof prospectId !== 'string') {
 			return fail(400, { message: 'Missing prospect ID' });
 		}
-		const prospect = await getProspectByIdForUser(user.id, prospectId);
+		const prospect = await getProspectByIdWithCreated(prospectId);
 		if (!prospect) return fail(404, { message: 'Prospect not found' });
 		if (!(prospect.demoLink ?? '').trim()) {
 			return fail(400, { message: 'No demo to approve. Create a demo first.' });
 		}
-		let demoTracking = await getDemoTrackingForProspect(user.id, prospectId);
+		let demoTracking = await getDemoTrackingForProspectLatest(prospectId);
 		if (!demoTracking) {
 			// Legacy: prospect has demo link but no demo_tracking row; create one as approved so Send is available
 			await upsertDemoTrackingForProspect(
@@ -213,7 +211,7 @@ export const actions: Actions = {
 		if (!prospectId || typeof prospectId !== 'string') {
 			return fail(400, { message: 'Missing prospect ID' });
 		}
-		const prospect = await getProspectByIdForUser(user.id, prospectId);
+		const prospect = await getProspectByIdWithCreated(prospectId);
 		if (!prospect) return fail(404, { message: 'Prospect not found' });
 		if (prospect.flagged && prospect.flaggedReason !== NO_FIT_GBP_REASON) {
 			return fail(400, { message: 'This prospect is out of scope.' });
@@ -244,7 +242,7 @@ export const actions: Actions = {
 		}
 		const kind: CrmOutreachKind =
 			kindRaw === 'alternate' ? 'alternate' : kindRaw === 'demo' ? 'demo' : 'demo';
-		const prospect = await getProspectByIdForUser(user.id, prospectId);
+		const prospect = await getProspectByIdWithCreated(prospectId);
 		if (!prospect) return fail(404, { message: 'Prospect not found' });
 		if (prospect.flagged && prospect.flaggedReason !== NO_FIT_GBP_REASON) {
 			return fail(400, { message: 'Prospect out of scope.' });
@@ -253,7 +251,7 @@ export const actions: Actions = {
 			if (!prospect.demoLink) {
 				return fail(400, { message: 'No demo link. Create a demo first.' });
 			}
-			const demoTracking = await getDemoTrackingForProspect(user.id, prospectId);
+			const demoTracking = await getDemoTrackingForProspectLatest(prospectId);
 			if (
 				demoTracking &&
 				demoTracking.status !== 'approved' &&
@@ -307,13 +305,13 @@ export const actions: Actions = {
 			return fail(400, { message: 'Missing prospect ID' });
 		}
 		const kind: CrmOutreachKind = kindRaw === 'alternate' ? 'alternate' : 'demo';
-		const prospect = await getProspectByIdForUser(user.id, prospectId);
+		const prospect = await getProspectByIdWithCreated(prospectId);
 		if (!prospect) return fail(404, { message: 'Prospect not found' });
 		if (prospect.flagged && prospect.flaggedReason !== NO_FIT_GBP_REASON) {
 			return fail(400, { message: 'Prospect out of scope.' });
 		}
 		const linkOrigin = getOriginForOutgoingLinks(url.origin);
-		let demoTracking = await getDemoTrackingForProspect(user.id, prospectId);
+		let demoTracking = await getDemoTrackingForProspectLatest(prospectId);
 
 		if (kind === 'demo') {
 			if (!prospect.demoLink) {
@@ -328,7 +326,7 @@ export const actions: Actions = {
 					(prospect.demoLink ?? '').trim(),
 					'approved'
 				);
-				demoTracking = await getDemoTrackingForProspect(user.id, prospectId);
+				demoTracking = await getDemoTrackingForProspectLatest(prospectId);
 			}
 			if (
 				!demoTracking ||
@@ -397,7 +395,7 @@ export const actions: Actions = {
 		if (!prospectId || typeof prospectId !== 'string') {
 			return fail(400, { message: 'Missing prospect ID' });
 		}
-		const prospect = await getProspectByIdForUser(user.id, prospectId);
+		const prospect = await getProspectByIdWithCreated(prospectId);
 		if (!prospect) return fail(404, { message: 'Prospect not found' });
 		const ex = await executeSendGmailOutreachDraft({
 			userId: user.id,


### PR DESCRIPTION
Fixes #78

## Summary
The CRM prospects list and detail page were filtered by the signed-in user's Google sub, preventing teammates from viewing each other's prospects. This change aligns the admin app with the intended shared internal workspace.

## Changes
- **List load:** `listProspects()` now includes global demo tracking, scraped data, and demo/GBP/insights job maps (`getDemoTrackingMapGlobal`, `getScrapedDataMapGlobal`, `*MapGlobal`).
- **Actions:** `clearStuckQueueStatus`, `bulkProcessNextStep`, and `bulkGenerateDemos` now use global maps and full prospect list.
- **Detail:** `getProspectByIdWithCreated` and prospect-scoped loaders (`getDemoTrackingForProspectLatest`, `getLatestDemoJobForProspect`, `*Latest` for GBP/insights).
- **Dashboard home:** Overview counts now use `listProspects()`.
- **PostgREST:** Added `.limit(5000)` on `listProspects` and `listProspectsForUser` in `prospects.ts`.

## Testing
Manual: Sign in as a second internal user, verify the full prospect list is visible, open another user's prospect, and verify dashboard counts and bulk actions work correctly.