### PR TITLE
feat(admin): CRM outreach email pipeline and preview UI

### DIFF
--- a/apps/admin/src/lib/server/agentContent.ts
+++ b/apps/admin/src/lib/server/agentContent.ts
@@ -8,6 +8,11 @@ import { getSupabaseAdmin } from '$lib/server/supabase';
 export type AgentId = 'design' | 'demo-chat' | 'demo-creation' | 'email' | 'gbp';
 export type ContentType = 'prompt' | 'knowledge_base';
 
+/** Dashboard Email AI Agent; must match `agent_content_versions` rows and `generateEmailCopy`. */
+export const EMAIL_AI_AGENT_ID: AgentId = 'email';
+/** Prompt key saved on Agents → Email AI; same key `getResolvedContent` uses for outreach copy. */
+export const EMAIL_AI_COPY_PROMPT_KEY = 'email_copy_prompt';
+
 export type AgentContentRow = {
 	id: string;
 	agent_id: string;
@@ -145,7 +150,7 @@ export const AGENT_CONTENT_KEYS = {
 		knowledge_base: ['demo_kb']
 	},
 	email: {
-		prompt: ['email_copy_prompt'],
+		prompt: [EMAIL_AI_COPY_PROMPT_KEY],
 		knowledge_base: []
 	},
 	gbp: {

--- a/apps/admin/src/lib/server/generateEmailCopy.ts
+++ b/apps/admin/src/lib/server/generateEmailCopy.ts
@@ -1,6 +1,10 @@
 import { env } from '$env/dynamic/private';
 import type { Prospect } from '$lib/server/prospects';
-import { getResolvedContent } from '$lib/server/agentContent';
+import {
+	getResolvedContent,
+	EMAIL_AI_AGENT_ID,
+	EMAIL_AI_COPY_PROMPT_KEY
+} from '$lib/server/agentContent';
 import { serverError, serverInfo } from '$lib/server/logger';
 import { getScrapedDataForProspectForUser } from '$lib/server/supabase';
 import { auditFromScrapedData, type DemoAudit } from '$lib/types/demo';
@@ -9,7 +13,7 @@ const GEMINI_API_KEY = env.GEMINI_API_KEY;
 const GEMINI_MODEL = 'gemini-2.5-flash';
 
 /**
- * Optional AI-written opening paragraph for the fixed upgrade-pitch email template in send.ts.
+ * Optional AI-written opening (greeting + hook) for the upgrade-pitch email template in send.ts.
  * Subject line and the rest of the body are assembled server-side.
  */
 export type EmailCopy = { openingHook?: string; bodyIntro?: string; subjectLine?: string };
@@ -24,11 +28,11 @@ const EMAIL_COPY_JSON_SCHEMA_INLINE = `
 Return ONLY a single JSON object (no markdown, no explanation) with these keys:
 {
   "subjectLine": "string, max 9 words, no quotes. Add a hook beyond the company name: tie to {{industry}}, a moment (after hours, first scroll, mobile), or a light question. Use lowercase except Title Case for the business name as given. Do NOT start with: idea for, thought about, something for, quick idea for, note for (those read as lazy). Include the company name or its main distinct words (never one generic industry word alone). Good examples: 'after-hours calls, Riverdale Dental', 'Riverdale Dental and the booking flow', 'first scroll on Riverdale Dental's site', 'worth a peek, Riverdale Dental'. Never use: prototype, upgrade, demo, redesign, mockup, audit, proposal, performance, solutions. No em dash (U+2014).",
-  "openingHook": "string, plain text only. One or two short sentences (max ~40 words total). Casual, human tone, like a colleague, not sales copy. Reference {{company}} by name once. Ground it in their industry ({{industry}}): a believable observation (e.g. after-hours calls, mobile booking, local search, front-desk load), not a generic audit. When prospect insight below is available (not all 'not on file'), weave one or two specific weaknesses from that insight naturally; do not quote numbers or list bullets. No greeting, no bullets, no links, no signature, no markdown, no product names (Voice AI, SEO Core, etc.). Do NOT use phrases like: performance gaps, high-performance, tech stack, bounce rates, integrated upgrades. Do not use em dashes (U+2014) or en dashes (U+2013); use commas or periods."
+  "openingHook": "string, plain text only. Start with a brief natural greeting (e.g. Hi, Hey, Hello, optionally with a name if you can infer one from {{company}}). Then one or two short sentences (max ~45 words total including the greeting). Casual, human tone, like a colleague, not sales copy. Reference {{company}} by name once outside the greeting if it fits. Ground it in their industry ({{industry}}): a believable observation (e.g. after-hours calls, mobile booking, local search, front-desk load), not a generic audit. When prospect insight below is available (not all 'not on file'), weave one or two specific weaknesses from that insight naturally; do not quote numbers or list bullets. No bullets, no links, no signature, no markdown, no product names (Voice AI, SEO Core, etc.). Do NOT use phrases like: performance gaps, high-performance, tech stack, bounce rates, integrated upgrades. Avoid the exact phrase 'Hi there,'. Do not use em dashes (U+2014) or en dashes (U+2013); use commas or periods."
 }`.trim();
 
 /** Default prompt for subject line + opening lines before the fixed demo-email template in send.ts. Placeholders: {{company}}, {{industry}}, {{senderName}}, {{gbp_score_line}}, {{gbp_interpretation}}, {{website_critique}}. */
-export const DEFAULT_EMAIL_COPY_PROMPT = `You write two things for a short cold email: a subject line and the first 1-2 sentences. A fixed template below your text will mention a link and a soft ask. The reader already gets "Hi there," from the template.
+export const DEFAULT_EMAIL_COPY_PROMPT = `You write two things for a short cold email: a subject line and the opening lines of the body. A fixed template after your opening will mention a link and a soft ask. The openingHook must include the greeting and your hook in one flow (no separate fixed salutation is added for you).
 
 Context:
 - Business/company name: {{company}}
@@ -54,11 +58,12 @@ subjectLine rules:
 - Banned words in subject: prototype, upgrade, demo, redesign, mockup, audit, proposal, performance, solutions.
 
 openingHook rules:
-- One or two sentences, max ~40 words, plain text.
+- Start with a short greeting, then your hook: two or three short sentences total, max ~45 words, plain text.
 - Sound specific to this business and industry, not templated. Prefer concrete situations local businesses in this industry care about (missed calls, booking friction, mobile, visibility). Avoid vague "I noticed your site" with no substance.
 - Tone: warm, brief, conversational. Not corporate, not consultative, not a feature list.
-- Forbidden: Hi/Hello/Hey, bullets, URLs, signatures, markdown, emoji, and buzzwords like "performance gaps", "high-performance", "leverage", "cutting-edge", "solutions".
-- Do not write metadata lines (no "title:", "subject:", "subject line:", or any key: value lines). openingHook is only the sentences that appear in the email body after "Hi there,".
+- Avoid the stale phrase "Hi there,"; vary the greeting (Hi, Hey, Hello, or a name if natural from {{company}}).
+- Forbidden: bullets, URLs, signatures, markdown, emoji, and buzzwords like "performance gaps", "high-performance", "leverage", "cutting-edge", "solutions".
+- Do not write metadata lines (no "title:", "subject:", "subject line:", or any key: value lines). openingHook is exactly what appears at the top of the email body before the fixed template lines.
 - Do not describe the prototype, link, or "interactive draft" in openingHook; the template adds that in the next sentence.
 
 ${EMAIL_COPY_JSON_SCHEMA_INLINE}`;
@@ -157,12 +162,25 @@ function repairJsonNewlines(raw: string): string {
 }
 
 /**
- * When JSON is truncated or malformed, try to pull subjectLine / openingHook with regex.
+ * When JSON is truncated or malformed, try to pull subject / body fields with regex.
  */
 function extractEmailCopyFieldsLoose(raw: string): { openingHook?: string; subjectLine?: string } {
 	const out: { openingHook?: string; subjectLine?: string } = {};
-	const pick = (key: 'subjectLine' | 'openingHook') => {
-		const re = new RegExp(`"${key}"\\s*:\\s*"((?:[^"\\\\]|\\\\.)*)`, 's');
+	const pickOpeningKey = (jsonKey: string): string | undefined => {
+		const re = new RegExp(`"${jsonKey}"\\s*:\\s*"((?:[^"\\\\]|\\\\.)*)`, 's');
+		const m = raw.match(re);
+		if (!m?.[1]) return undefined;
+		const unescaped = m[1]
+			.replace(/\\n/g, '\n')
+			.replace(/\\r/g, '\r')
+			.replace(/\\"/g, '"')
+			.replace(/\\\\/g, '\\');
+		const t = unescaped.trim();
+		return t || undefined;
+	};
+	const pickSubject = (jsonKey: string) => {
+		if (out.subjectLine) return;
+		const re = new RegExp(`"${jsonKey}"\\s*:\\s*"((?:[^"\\\\]|\\\\.)*)`, 's');
 		const m = raw.match(re);
 		if (!m?.[1]) return;
 		const unescaped = m[1]
@@ -171,10 +189,15 @@ function extractEmailCopyFieldsLoose(raw: string): { openingHook?: string; subje
 			.replace(/\\"/g, '"')
 			.replace(/\\\\/g, '\\');
 		const t = unescaped.trim();
-		if (t) out[key] = t;
+		if (t) out.subjectLine = t;
 	};
-	pick('subjectLine');
-	pick('openingHook');
+	pickSubject('subjectLine');
+	pickSubject('subject');
+	/** Prefer bodyIntro (long-form prompts) over openingHook when both appear in broken JSON. */
+	const hookFromBodyIntro = pickOpeningKey('bodyIntro') ?? pickOpeningKey('body_intro');
+	const hookFromOpening = pickOpeningKey('openingHook');
+	if (hookFromBodyIntro) out.openingHook = hookFromBodyIntro;
+	else if (hookFromOpening) out.openingHook = hookFromOpening;
 	return out;
 }
 
@@ -193,13 +216,13 @@ function normalizeEmailCopyShape(input: unknown): { openingHook?: string; subjec
 	const subjectLine = (subjectCandidates.find((v) => typeof v === 'string' && v.trim().length > 0) as string | undefined)?.trim();
 
 	const hookCandidates: unknown[] = [
+		obj.bodyIntro,
+		obj.body_intro,
 		obj.personalizedOpener,
 		obj.personalized_opener,
 		obj.openingHook,
 		obj.opening_hook,
 		obj.hook,
-		obj.bodyIntro,
-		obj.body_intro,
 		obj.body,
 		obj.intro,
 		obj.message,
@@ -244,8 +267,9 @@ function sanitizeSubjectLine(raw: string | undefined): string {
 	if (text.length > 100) text = text.slice(0, 100).trim();
 	const words = text.split(/\s+/).filter(Boolean);
 	if (words.length < 2) return '';
-	const banned = /\b(prototype|upgrade|demo|redesign|mockup|audit|proposal|performance|solutions)\b/i;
-	if (banned.test(text)) return '';
+	/** Allow audit, demo, prototype, etc.; custom Email AI prompts need those words. */
+	const spammy = /\b(performance gaps|high-performance)\b/i;
+	if (spammy.test(text)) return '';
 	if (/[{}]/.test(text)) return '';
 	if (/^(title|subject)\s*:/i.test(text)) return '';
 	text = text.replace(/\s*[—–]\s*/g, ', ').replace(/,\s*,+/g, ',').trim();
@@ -255,29 +279,29 @@ function sanitizeSubjectLine(raw: string | undefined): string {
 const METADATA_LINE =
 	/^(title|subject|subject\s*line|email\s*subject|headline)\s*:\s*/i;
 
+const URL_IN_BODY = /https?:\/\/[^\s]+/gi;
+
 function sanitizeOpeningHook(raw: string): string {
 	let text = raw.replace(/\r/g, '').trim();
 	if (/^\s*[\[{]/.test(text) || /"subjectLine"\s*:/i.test(text)) return '';
-	/** Match CTA-ish lines only; avoid stripping hooks that use "take a look" in natural prose. */
-	const bannedLine =
-		/(view your demo|view the \S+ upgrade|take a look at (the|your) (demo|draft|link|prototype)|ednsy\.com|^-\s|https?:\/\/|performance gaps|high-performance|tech stack|bounce rates)/i;
-	const kept = text
-		.split('\n')
-		.map((line) => line.trim())
-		.filter(
-			(line) =>
-				line.length > 0 &&
-				!bannedLine.test(line) &&
-				!METADATA_LINE.test(line) &&
-				!/^(hi|hey|hello)[,!\s]*$/i.test(line)
-		);
+	/** Paragraphs (double newline); strip URLs instead of dropping whole blocks (critique context often has https). */
+	const blocks = text
+		.split(/\n\s*\n/)
+		.map((b) => b.trim().replace(/\n/g, ' ').replace(/\s+/g, ' '))
+		.filter(Boolean);
+	/** Match spammy CTAs; do not match bare "https" (handled by stripping URLs). */
+	const bannedBlock =
+		/(view your demo|view the \S+ upgrade|take a look at (the|your) (demo|draft|link|prototype)|ednsy\.com|^-\s|performance gaps|high-performance|tech stack|bounce rates)/i;
+	const kept = blocks
+		.map((b) => b.replace(URL_IN_BODY, '').trim())
+		.filter((b) => b.length > 0 && !bannedBlock.test(b) && !METADATA_LINE.test(b));
 	text = kept
-		.join(' ')
+		.join('\n\n')
 		.replace(/\s*[—–]\s*/g, ', ')
 		.replace(/,\s*,+/g, ',')
-		.replace(/\s{2,}/g, ' ')
 		.trim();
-	if (text.length > 350) text = text.slice(0, 350).trim();
+	const maxLen = 12000;
+	if (text.length > maxLen) text = text.slice(0, maxLen).trim();
 	return text;
 }
 
@@ -293,13 +317,11 @@ function looksLikeBrokenModelOpening(opening: string): boolean {
 	}
 	if (/\btitle\s*:/i.test(opening) || /\bsubject\s*line\s*:/i.test(opening)) return true;
 	if (/^\s*[{[]/.test(opening)) return true;
-	const braceCount = (combined.match(/[{}]/g) ?? []).length;
-	if (braceCount >= 2) return true;
 	return false;
 }
 
 /**
- * Optional AI opening paragraph for the upgrade-pitch template. Returns copy: null on hard failure;
+ * Optional AI opening (greeting + hook) for the upgrade-pitch template. Returns copy: null on hard failure;
  * copy: {} when generation succeeded but the hook is omitted or stripped (use default opening in send.ts).
  */
 export async function generateEmailCopy(
@@ -307,10 +329,6 @@ export async function generateEmailCopy(
 	senderName: string,
 	userId: string
 ): Promise<GenerateEmailCopyResult> {
-	if (!GEMINI_API_KEY) {
-		return { copy: null, promptSource: 'default', error: 'GEMINI_API_KEY is not configured' };
-	}
-
 	const company = prospect.companyName || 'the business';
 	const industry = prospect.industry || 'your business';
 
@@ -318,12 +336,22 @@ export async function generateEmailCopy(
 	const audit = auditFromScrapedData(scraped);
 	const { gbpScoreLine, gbpInterpretation, websiteCritique } = buildEmailCopyContext(audit);
 
+	/** Same row as Dashboard → Agents → Email AI Agent → Email copy prompt (`agent_content_versions`). */
 	const resolved = await getResolvedContent(
-		'email',
+		EMAIL_AI_AGENT_ID,
 		'prompt',
-		'email_copy_prompt',
+		EMAIL_AI_COPY_PROMPT_KEY,
 		DEFAULT_EMAIL_COPY_PROMPT
 	);
+
+	if (!GEMINI_API_KEY) {
+		return {
+			copy: null,
+			promptSource: resolved.source,
+			error: 'GEMINI_API_KEY is not configured'
+		};
+	}
+
 	const prompt = resolved.body
 		.replace(/\{\{company\}\}/g, company)
 		.replace(/\{\{industry\}\}/g, industry)
@@ -341,13 +369,17 @@ export async function generateEmailCopy(
 			body: JSON.stringify({
 				contents: [{ role: 'user', parts: [{ text: prompt }] }],
 				generationConfig: {
-					/** Short JSON; 1024 avoids rare MAX_TOKENS truncation mid-object ("Unexpected end of JSON input"). */
-					maxOutputTokens: 1024,
+					/**
+					 * Long multi-paragraph bodyIntro + JSON wrapper needs a high ceiling. 2048 often
+					 * hits MAX_TOKENS mid-string (looks like random truncation, e.g. "your 90" with no "/100").
+					 */
+					maxOutputTokens: 8192,
 					temperature: 0.7,
 					responseMimeType: 'application/json'
 				}
 			}),
-			signal: AbortSignal.timeout(10000)
+			/** Long prompts + 2k tokens often exceed 10s; avoid spurious TimeoutError on preview / draft. */
+			signal: AbortSignal.timeout(60_000)
 		});
 
 		if (!res.ok) {
@@ -427,6 +459,12 @@ export async function generateEmailCopy(
 		let clean = sanitizeOpeningHook(openingHook);
 		if (!clean || looksLikeBrokenModelOpening(clean)) {
 			return { copy: { subjectLine: subjectLine || undefined }, promptSource: resolved.source };
+		}
+
+		if (finishReason === 'MAX_TOKENS') {
+			serverInfo('generateEmailCopy', 'Gemini MAX_TOKENS; email body may be cut off mid-sentence', {
+				bodyIntroChars: clean.length
+			});
 		}
 
 		return {

--- a/apps/admin/src/lib/server/send.ts
+++ b/apps/admin/src/lib/server/send.ts
@@ -131,6 +131,27 @@ export function getAlternateOfferSubject(companyName: string): string {
 	return `Quick idea for ${companyName}`;
 }
 
+/** Escape plain text and turn newlines into `<br />` (no `<p>` wrappers). */
+function plainToBrHtml(plain: string): string {
+	return escapeHtml(plain.trim().replace(/\r/g, '')).replace(/\n/g, '<br />');
+}
+
+/**
+ * Gmail-friendly typography for CRM outreach bodies. System UI stack (no web fonts; clients vary).
+ * max-width keeps line length readable on wide screens; many clients honor it.
+ */
+const OUTREACH_EMAIL_BODY_STYLE =
+	"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 1.55; color: #171717; max-width: 34em;";
+
+const OUTREACH_EMAIL_LINK_STYLE = 'color: #1d4ed8; font-weight: 500; text-decoration: underline;';
+
+function wrapOutreachEmailHtml(inner: string): string {
+	const t = inner.trim();
+	if (!t) return '';
+	if (/^\s*<!DOCTYPE/i.test(t) || /<html[\s>]/i.test(t)) return t;
+	return `<div style="${OUTREACH_EMAIL_BODY_STYLE}">${t}</div>`;
+}
+
 /**
  * Build email HTML for alternate offer (AI agent, voice AI, SEO) when we're not sending a website demo.
  * No demo link; short outcome-focused pitch and soft CTA.
@@ -140,18 +161,16 @@ export function buildEmailBodyAlternateOffer(
 	senderName: string,
 	_origin: string
 ): string {
-	const company = escapeHtml(prospect.companyName || 'your business');
-	const safeSender = escapeHtml(senderName);
-	const html = `
-<p>Hi there,</p>
-<p>I had a quick look at how ${company} shows up online. A lot of local businesses like yours leave calls and bookings on the table after hours or when the desk is slammed, and it&apos;s hard to stay visible in local search without constant attention.</p>
-<p>We help with 24/7 phone coverage (AI answers and books) and tightening local SEO / Google Business so more people find you when they search. If that sounds worth a short chat, reply here and we can figure out what would actually help ${company}.</p>
-<p>Best,</p>
-<p>${safeSender}</p>
-<hr style="margin-top:1.5em; border:none; border-top:1px solid #eee;" />
-<p style="font-size:0.85em; color:#666;">${LEGAL_COMPANY_NAME} | ${LEGAL_COMPANY_ADDRESS}</p>
-`.trim();
-	return html;
+	const company = prospect.companyName || 'your business';
+	const block1 = `Hi. I had a quick look at how ${company} shows up online. A lot of local businesses like yours leave calls and bookings on the table after hours or when the desk is slammed, and it's hard to stay visible in local search without constant attention.`;
+	const block2 = `We help with 24/7 phone coverage (AI answers and books) and tightening local SEO / Google Business so more people find you when they search. If that sounds worth a short chat, reply here and we can figure out what would actually help ${company}.`;
+	const inner =
+		[plainToBrHtml(block1), plainToBrHtml(block2), plainToBrHtml('Best,'), escapeHtml(senderName)].join(
+			'<br /><br />'
+		) +
+		`<hr style="margin-top:1.5em; border:none; border-top:1px solid #eee;" />` +
+		`<div style="font-size:0.85em; color:#666;">${LEGAL_COMPANY_NAME} | ${LEGAL_COMPANY_ADDRESS}</div>`;
+	return wrapOutreachEmailHtml(inner);
 }
 
 /**
@@ -178,11 +197,20 @@ function getEmailClosingSignatureLine(senderName: string, signatureOverride: str
 
 function defaultUpgradeOpeningParagraph(company: string): string {
 	const c = company.trim() || 'your business';
-	return `I was thinking about how ${c} reads to a first-time visitor who is still deciding if they're in the right place. I noticed a few spots where the next step could feel clearer.`;
+	return `Hi, I was thinking about how ${c} reads to a first-time visitor who is still deciding if they're in the right place. I noticed a few spots where the next step could feel clearer.`;
 }
 
 /**
- * Short demo outreach HTML: AI opener + prototype CTA + soft close. No feature bullet list.
+ * Long multi-paragraph Email AI copy already includes offer + CTA; append only the tracked link and signature.
+ */
+function isFullLetterOpeningPlain(plain: string): boolean {
+	const t = plain.trim();
+	if (t.length >= 500) return true;
+	return t.split(/\n\s*\n/).filter((b) => b.trim().length > 0).length >= 3;
+}
+
+/**
+ * Short demo outreach HTML: opening (AI or default greeting + hook) + prototype CTA + soft close.
  * Tracking: link = /api/demo/click, pixel = /api/demo/open.
  */
 export function buildEmailBodyUpgradePitch(
@@ -197,20 +225,26 @@ export function buildEmailBodyUpgradePitch(
 	const trackableLink = `${origin}/api/demo/click?p=${encodeURIComponent(prospect.id)}`;
 	const pixelUrl = `${origin}/api/demo/open?p=${encodeURIComponent(prospect.id)}`;
 	const openingPlain = (options?.openingHook ?? '').trim() || defaultUpgradeOpeningParagraph(company);
-	const openingHtml = `<p>${escapeHtml(openingPlain).replace(/\n/g, '<br />\n')}</p>`;
 	const closingSig = escapeHtml(getEmailClosingSignatureLine(senderName, signatureOverride ?? null));
 	const linkLabel = `See the ${companySafe} prototype`;
-	const html = `
-<p>Hi there,</p>
-${openingHtml}
-<p>I mocked that up as a simple interactive draft for ${companySafe}. Easier to skim than a long write-up. If you have two minutes:</p>
-<p><a href="${trackableLink}">${linkLabel}</a></p>
-<p>No strings attached. Just curious what you think.</p>
-<p>Best,</p>
-<p>${closingSig}</p>
-<img src="${pixelUrl}" width="1" height="1" alt="" style="display:block;width:1px;height:1px;border:0;" />
-`.trim();
-	return html;
+	const fullLetter = isFullLetterOpeningPlain(openingPlain);
+	const segments: string[] = [plainToBrHtml(openingPlain)];
+	if (!fullLetter) {
+		segments.push(
+			plainToBrHtml(
+				`I mocked that up as a simple interactive draft for ${company}. Easier to skim than a long write-up. If you have two minutes:`
+			)
+		);
+	}
+	segments.push(`<a href="${trackableLink}" style="${OUTREACH_EMAIL_LINK_STYLE}">${linkLabel}</a>`);
+	if (!fullLetter) {
+		segments.push(plainToBrHtml('No strings attached. Just curious what you think.'));
+	}
+	segments.push(plainToBrHtml('Best,'), closingSig);
+	const inner =
+		segments.join('<br /><br />') +
+		`<img src="${pixelUrl}" width="1" height="1" alt="" style="display:block;width:1px;height:1px;border:0;" />`;
+	return wrapOutreachEmailHtml(inner);
 }
 
 /**
@@ -232,6 +266,11 @@ export type EmailTemplateVars = {
 	trackableLink: string;
 	senderName: string;
 	pixelUrl: string;
+	/**
+	 * Plain-text opening from Email AI Agent (saved prompt + Gemini). Injected via
+	 * `{{openingHook}}` (escaped, newlines to `<br />`) or prepended when the placeholder is absent.
+	 */
+	openingHookPlain?: string | null;
 };
 
 /**
@@ -242,13 +281,21 @@ export function buildEmailBodyFromTemplate(
 	templateHtml: string,
 	vars: EmailTemplateVars
 ): string {
-	let body = templateHtml
+	const hookPlain = (vars.openingHookPlain ?? '').trim();
+	const hookHtml = hookPlain ? plainToBrHtml(hookPlain) : '';
+	let body = templateHtml;
+	if (body.includes('{{openingHook}}')) {
+		body = body.replace(/\{\{openingHook\}\}/g, hookHtml);
+	} else if (hookHtml) {
+		body = `${hookHtml}\n${body}`;
+	}
+	body = body
 		.replace(/\{\{companyName\}\}/g, escapeHtml(vars.companyName))
 		.replace(/\{\{demoLink\}\}/g, vars.demoLink)
 		.replace(/\{\{trackableLink\}\}/g, vars.trackableLink)
 		.replace(/\{\{senderName\}\}/g, escapeHtml(vars.senderName));
 	const footer = `<img src="${vars.pixelUrl}" width="1" height="1" alt="" style="display:block;width:1px;height:1px;border:0;" />`;
-	return body.trim() + footer;
+	return wrapOutreachEmailHtml(body.trim() + footer);
 }
 
 export function escapeHtml(s: string): string {
@@ -261,13 +308,15 @@ export function escapeHtml(s: string): string {
 
 /**
  * Build email body for sending: uses custom template when provided, otherwise default.
+ * When `openingHook` is set, it is merged into a custom template (see {@link EmailTemplateVars.openingHookPlain}).
  */
 export function buildEmailBodyForUser(
 	prospect: Prospect,
 	demoLink: string,
 	senderName: string,
 	origin: string,
-	customEmailHtml: string | null
+	customEmailHtml: string | null,
+	options?: { openingHook?: string | null }
 ): string {
 	const company = prospect.companyName || 'your business';
 	const trackableLink = `${origin}/api/demo/click?p=${encodeURIComponent(prospect.id)}`;
@@ -277,12 +326,15 @@ export function buildEmailBodyForUser(
 		demoLink,
 		trackableLink,
 		senderName,
-		pixelUrl
+		pixelUrl,
+		openingHookPlain: options?.openingHook ?? null
 	};
 	if (customEmailHtml?.trim()) {
 		return buildEmailBodyFromTemplate(customEmailHtml.trim(), vars);
 	}
-	return buildEmailBody(prospect, demoLink, senderName, origin);
+	return buildEmailBodyUpgradePitch(prospect, senderName, origin, null, {
+		openingHook: options?.openingHook ?? null
+	});
 }
 
 /** Banned openings that read as empty "name-only" subjects. */
@@ -328,7 +380,7 @@ function isAcceptableAiOutreachSubject(subject: string, companyName: string): bo
 	return significant.some((tok) => s.includes(tok));
 }
 
-/** Optional AI paragraph for the upgrade-pitch template (see {@link buildEmailBodyUpgradePitch}). */
+/** Optional AI opening (greeting + hook) for the upgrade-pitch template (see {@link buildEmailBodyUpgradePitch}). */
 export type DemoEmailAiCopy = { openingHook?: string; bodyIntro?: string; subjectLine?: string };
 
 export type DemoEmailGenerationResult = {
@@ -339,7 +391,7 @@ export type DemoEmailGenerationResult = {
 
 /**
  * Subject + HTML for “send demo” email: upgrade-pitch template, optional custom user HTML template,
- * optional AI opening paragraph. Fails when a custom Email AI prompt is active but generation returned no copy.
+ * optional AI opening (greeting + hook). Fails when a custom Email AI prompt is active but generation returned no copy.
  */
 export function resolveDemoOutreachEmail(
 	prospect: Prospect,
@@ -372,7 +424,8 @@ export function resolveDemoOutreachEmail(
 				prospect.demoLink ?? '',
 				senderName,
 				linkOrigin,
-				emailHtmlTemplate
+				emailHtmlTemplate,
+				{ openingHook }
 			)
 		};
 	}

--- a/apps/admin/src/routes/dashboard/agents/+page.server.ts
+++ b/apps/admin/src/routes/dashboard/agents/+page.server.ts
@@ -6,6 +6,7 @@ import {
 	getResolvedContent,
 	saveAgentContent,
 	AGENT_CONTENT_KEYS,
+	EMAIL_AI_COPY_PROMPT_KEY,
 	type AgentId
 } from '$lib/server/agentContent';
 import { DEFAULT_TONE_PROMPT_TEMPLATE } from '$lib/server/generateTone';
@@ -34,7 +35,7 @@ const DEFAULTS: Record<AgentId, Record<string, Record<string, string>>> = {
 		knowledge_base: { demo_kb: '' }
 	},
 	email: {
-		prompt: { email_copy_prompt: DEFAULT_EMAIL_COPY_PROMPT },
+		prompt: { [EMAIL_AI_COPY_PROMPT_KEY]: DEFAULT_EMAIL_COPY_PROMPT },
 		knowledge_base: {}
 	},
 	gbp: {
@@ -50,7 +51,7 @@ const KEY_LABELS: Record<string, string> = {
 	audit: 'Audit prompt',
 	audit_modal_copy: 'Audit modal copy',
 	demo_kb: 'Demo knowledge base',
-	email_copy_prompt: 'Email copy prompt',
+	[EMAIL_AI_COPY_PROMPT_KEY]: 'Email copy prompt',
 	grade_prompt: 'GBP grade prompt'
 };
 
@@ -127,7 +128,8 @@ export const actions: Actions = {
 			return { success: false, error: 'Invalid request' };
 		}
 		const keys = AGENT_CONTENT_KEYS[agentId as AgentId];
-		if (!keys?.[contentType as 'prompt' | 'knowledge_base']?.includes(key)) {
+		const allowedKeys = keys?.[contentType as 'prompt' | 'knowledge_base'] as readonly string[] | undefined;
+		if (!allowedKeys?.includes(key)) {
 			return { success: false, error: 'Invalid key' };
 		}
 		const result = await saveAgentContent(

--- a/apps/admin/src/routes/dashboard/prospects/[id]/+page.svelte
+++ b/apps/admin/src/routes/dashboard/prospects/[id]/+page.svelte
@@ -897,7 +897,7 @@
 
 	<Dialog.Root bind:open={outreachDialogOpen}>
 		<Dialog.Content
-			class="max-w-[calc(100vw-2rem)] max-h-[min(90dvh,900px)] w-[min(100%,48rem)] flex min-h-0 flex-col gap-0 sm:max-w-3xl"
+			class="flex max-h-[min(96dvh,1400px)] w-[min(100%,48rem)] min-h-0 max-w-[calc(100vw-2rem)] flex-col gap-0 sm:max-w-3xl"
 		>
 			<Dialog.Header class="shrink-0 pr-6">
 				<Dialog.Title>Review outreach email</Dialog.Title>
@@ -931,7 +931,7 @@
 							class="w-full"
 						/>
 					</div>
-					<div class="flex min-h-0 flex-col gap-2">
+					<div class="flex min-h-[min(52dvh,32rem)] flex-1 flex-col gap-2">
 						<div class="flex shrink-0 items-center justify-between gap-3">
 							<Label for="outreach-html-{prospect.id}" class="mb-0">Body</Label>
 							<div
@@ -968,13 +968,13 @@
 									name="outreachHtml"
 									form={createGmailDraftFormId}
 									bind:value={previewHtml}
-									class="field-sizing-fixed box-border w-full min-h-[12rem] max-h-[min(42dvh,20rem)] font-mono text-xs leading-relaxed sm:min-h-[14rem] sm:max-h-[min(48dvh,24rem)] sm:text-sm md:max-h-[min(52dvh,28rem)] pb-4"
+									class="field-sizing-fixed box-border w-full min-h-[min(52dvh,22rem)] max-h-[min(72dvh,46rem)] font-mono text-xs leading-relaxed sm:min-h-[min(56dvh,24rem)] sm:max-h-[min(76dvh,50rem)] sm:text-sm md:max-h-[min(80dvh,54rem)] pb-4"
 									spellcheck={false}
 								/>
 							{:else}
 								<input type="hidden" name="outreachHtml" form={createGmailDraftFormId} value={previewHtml} />
 								<iframe
-									class="box-border block w-full min-h-[12rem] max-h-[min(42dvh,20rem)] rounded-md border border-border bg-background sm:min-h-[14rem] sm:max-h-[min(48dvh,24rem)] md:max-h-[min(52dvh,28rem)]"
+									class="box-border block w-full min-h-[min(52dvh,22rem)] max-h-[min(72dvh,46rem)] rounded-md border border-border bg-background sm:min-h-[min(56dvh,24rem)] sm:max-h-[min(76dvh,50rem)] md:max-h-[min(80dvh,54rem)]"
 									title="Email preview"
 									srcdoc={previewHtml}
 									sandbox="allow-same-origin"


### PR DESCRIPTION
Fixes #89

## Summary
- **Email AI agent:** Shared `EMAIL_AI_AGENT_ID` / `EMAIL_AI_COPY_PROMPT_KEY`; `generateEmailCopy` resolves the same DB prompt as Dashboard → Agents. Custom `mail_html` templates get AI opening via `{{openingHook}}` or prepend; fixed TypeScript on agents save (`includes` on empty key lists).
- **Body / template:** Removed hardcoded salutation; long-form `bodyIntro` supported (URL strip vs dropping paragraphs, no false brace heuristic, 12k sanitizer cap, prefer `bodyIntro` in normalization and loose JSON). `buildEmailBodyUpgradePitch` uses full-letter mode to skip duplicate boilerplate when appropriate.
- **Gmail HTML:** Plain-to-`<br />` assembly, optional typography wrapper, link styles; alternate-offer email aligned.
- **Gemini:** `maxOutputTokens` 8192, 60s timeout, log when `finishReason === MAX_TOKENS`.
- **UI:** Outreach review dialog taller (viewport-based min/max heights); width unchanged (`max-w-3xl`).

## Files
- `pps/admin/src/lib/server/agentContent.ts`
- `pps/admin/src/lib/server/generateEmailCopy.ts`
- `pps/admin/src/lib/server/send.ts`
- `pps/admin/src/routes/dashboard/agents/+page.server.ts`
- `pps/admin/src/routes/dashboard/prospects/[id]/+page.svelte`

Made with [Cursor](https://cursor.com)