### PR TITLE
fix(admin): demo_tracking stage updates for shared workspace

### DIFF
--- a/apps/admin/src/lib/server/crmOutreachGmail.ts
+++ b/apps/admin/src/lib/server/crmOutreachGmail.ts
@@ -11,7 +11,7 @@ import {
 	GMAIL_OUTREACH_EVENT_DRAFT_CREATED,
 	GMAIL_OUTREACH_EVENT_SENT,
 	GMAIL_OUTREACH_EVENT_DRAFT_EXPIRED,
-	getDemoTrackingForProspect
+	getDemoTrackingForProspectLatest
 } from '$lib/server/supabase';
 import { getEffectiveEmailSenderName } from '$lib/server/userSettings';
 import { prepareCrmOutreachEmail, type CrmOutreachKind } from '$lib/server/crmOutreachEmail';
@@ -111,7 +111,7 @@ export async function executeCreateGmailOutreachDraft(params: {
 	if (!persist.ok) return { ok: false, error: persist.error ?? 'Failed to save draft id' };
 
 	if (setDemoTrackingEmailDraft && kind === 'demo') {
-		await updateDemoTrackingStatus(userId, prospectId, { status: 'email_draft' });
+		await updateDemoTrackingStatus(prospectId, { status: 'email_draft' });
 	}
 
 	await recordDemoEvent(prospectId, GMAIL_OUTREACH_EVENT_DRAFT_CREATED, {
@@ -146,9 +146,9 @@ export async function executeSendGmailOutreachDraft(params: {
 
 	const kind = prospect.gmailOutreachDraftKind;
 	if (kind === 'demo') {
-		const demoTracking = await getDemoTrackingForProspect(userId, prospectId);
+		const demoTracking = await getDemoTrackingForProspectLatest(prospectId);
 		if (demoTracking) {
-			await updateDemoTrackingStatus(userId, prospectId, { status: 'sent' });
+			await updateDemoTrackingStatus(prospectId, { status: 'sent' });
 		}
 	}
 
@@ -172,9 +172,9 @@ async function revertStaleDraft(
 ): Promise<void> {
 	await updateProspectGmailOutreachDraft(prospectId, { clear: true });
 	if (kind === 'demo') {
-		const demoTracking = await getDemoTrackingForProspect(userId, prospectId);
+		const demoTracking = await getDemoTrackingForProspectLatest(prospectId);
 		if (demoTracking?.status === 'email_draft') {
-			await updateDemoTrackingStatus(userId, prospectId, { status: 'approved' });
+			await updateDemoTrackingStatus(prospectId, { status: 'approved' });
 		}
 	}
 	await recordDemoEvent(prospectId, GMAIL_OUTREACH_EVENT_DRAFT_EXPIRED, {

--- a/apps/admin/src/lib/server/processGbpJob.ts
+++ b/apps/admin/src/lib/server/processGbpJob.ts
@@ -8,7 +8,7 @@
 
 import { getProspectByIdForUser, updateProspectFromGbp, updateProspectStatus, setProspectFlagged } from '$lib/server/prospects';
 import {
-	getDemoTrackingForProspect,
+	getDemoTrackingForProspectLatest,
 	claimNextPendingGbpJob,
 	updateGbpJob,
 	upsertDemoTrackingForProspect,
@@ -106,14 +106,15 @@ export async function processOneGbpJob(): Promise<ProcessGbpJobResult> {
 			...(gbpGradeResult.ok ? { gbpGrade: gbpGradeResult.data } : {})
 		} as Record<string, unknown>;
 
-		const existingRow = await getDemoTrackingForProspect(userId, prospectId);
+		const trackingOwnerId = prospect.userId ?? userId;
+		const existingRow = await getDemoTrackingForProspectLatest(prospectId);
 		const status: DemoTrackingStatus =
 			existingRow?.status && isValidDemoTrackingStatus(existingRow.status)
 				? (existingRow.status as DemoTrackingStatus)
 				: 'draft';
 		if (!existingRow) {
 			await upsertDemoTrackingForProspect(
-				userId,
+				trackingOwnerId,
 				prospectId,
 				prospect.provider ?? 'manual',
 				prospect.provider_row_id ?? prospectId,
@@ -121,7 +122,7 @@ export async function processOneGbpJob(): Promise<ProcessGbpJobResult> {
 				'draft'
 			);
 		}
-		const updateResult = await updateDemoTrackingStatus(userId, prospectId, {
+		const updateResult = await updateDemoTrackingStatus(prospectId, {
 			status,
 			scrapedData
 		});

--- a/apps/admin/src/lib/server/processInsightsJob.ts
+++ b/apps/admin/src/lib/server/processInsightsJob.ts
@@ -8,7 +8,7 @@
 
 import { getProspectByIdForUser, updateProspectFromGbp, updateProspectStatus, updateProspectIndustry } from '$lib/server/prospects';
 import {
-	getDemoTrackingForProspect,
+	getDemoTrackingForProspectLatest,
 	claimNextPendingInsightsJob,
 	updateInsightsJob,
 	upsertDemoTrackingForProspect,
@@ -254,14 +254,15 @@ export async function processOneInsightsJob(): Promise<ProcessInsightsJobResult>
 			scrapedData.insight = insightResult.data;
 		}
 
-		const existingRow = await getDemoTrackingForProspect(userId, prospectId);
+		const trackingOwnerId = prospect.userId ?? userId;
+		const existingRow = await getDemoTrackingForProspectLatest(prospectId);
 		const status: DemoTrackingStatus =
 			existingRow?.status && isValidDemoTrackingStatus(existingRow.status)
 				? (existingRow.status as DemoTrackingStatus)
 				: 'draft';
 		if (!existingRow) {
 			await upsertDemoTrackingForProspect(
-				userId,
+				trackingOwnerId,
 				prospectId,
 				prospect.provider ?? 'manual',
 				prospect.provider_row_id ?? prospectId,
@@ -269,7 +270,7 @@ export async function processOneInsightsJob(): Promise<ProcessInsightsJobResult>
 				'draft'
 			);
 		}
-		const updateResult = await updateDemoTrackingStatus(userId, prospectId, {
+		const updateResult = await updateDemoTrackingStatus(prospectId, {
 			status,
 			scrapedData
 		});

--- a/apps/admin/src/lib/server/supabase.ts
+++ b/apps/admin/src/lib/server/supabase.ts
@@ -121,16 +121,26 @@ export type UpdateDemoTrackingOptions = {
 };
 
 /**
- * Update status (and optionally send_time, scraped_data) for a demo_tracking row by prospect_id.
+ * Update status (and optionally send_time, scraped_data) for the latest demo_tracking row for this prospect.
+ * Matches shared-dashboard reads (`getDemoTrackingForProspectLatest`): any teammate can update the same row.
  * When status is 'sent' and sendTime is omitted, sets send_time to now().
  */
 export async function updateDemoTrackingStatus(
-	userId: string,
 	prospectId: string,
 	options: UpdateDemoTrackingOptions
 ): Promise<{ ok: boolean; error?: string }> {
 	const supabase = getSupabaseAdmin();
 	if (!supabase) return { ok: false, error: 'Supabase not configured' };
+	const { data: row, error: selErr } = await supabase
+		.from('demo_tracking')
+		.select('id')
+		.eq('prospect_id', prospectId)
+		.order('updated_at', { ascending: false })
+		.limit(1)
+		.maybeSingle();
+	if (selErr) return { ok: false, error: selErr.message };
+	if (!row?.id) return { ok: false, error: 'No demo tracking row for this prospect' };
+
 	const sendTime =
 		options.status === 'sent' && options.sendTime === undefined
 			? new Date().toISOString()
@@ -141,12 +151,13 @@ export async function updateDemoTrackingStatus(
 	};
 	if (sendTime !== undefined) updates.send_time = sendTime;
 	if (options.scrapedData !== undefined) updates.scraped_data = options.scrapedData;
-	const { error } = await supabase
+	const { data: updated, error } = await supabase
 		.from('demo_tracking')
 		.update(updates)
-		.eq('user_id', userId)
-		.eq('prospect_id', prospectId);
+		.eq('id', row.id)
+		.select('id');
 	if (error) return { ok: false, error: error.message };
+	if (!updated?.length) return { ok: false, error: 'Demo tracking row could not be updated' };
 	return { ok: true };
 }
 

--- a/apps/admin/src/routes/api/demo/generation-callback/+server.ts
+++ b/apps/admin/src/routes/api/demo/generation-callback/+server.ts
@@ -120,7 +120,7 @@ export const POST: RequestHandler = async ({ request, url }) => {
 				demoLink,
 				'draft'
 			);
-			await updateDemoTrackingStatus(userId, prospectId, { status: 'draft' });
+			await updateDemoTrackingStatus(prospectId, { status: 'draft' });
 		}
 	}
 

--- a/apps/admin/src/routes/dashboard/+page.server.ts
+++ b/apps/admin/src/routes/dashboard/+page.server.ts
@@ -15,8 +15,7 @@ import {
 	getPlacesMonthlyLimit,
 	updateDemoTrackingStatus,
 	upsertDemoTrackingForProspect,
-	enqueueDemoJob,
-	getDemoTrackingForProspect
+	enqueueDemoJob
 } from '$lib/server/supabase';
 import { getScrapedDataForDemo, formatScrapedDataErrorMessage } from '$lib/server/gbp';
 import type { PageServerLoad, Actions } from './$types';
@@ -124,11 +123,12 @@ export const actions: Actions = {
 			return fail(502, { message: result.error ?? 'Failed to update prospect' });
 		}
 		const supabase = getSupabaseAdmin();
+		const trackingOwnerId = prospect.userId ?? user.id;
 		if (supabase) {
 			const crmSource = prospect.provider ?? 'manual';
 			const crmProspectId = prospect.provider_row_id ?? prospectId;
 			await upsertDemoTrackingForProspect(
-				user.id,
+				trackingOwnerId,
 				prospectId,
 				crmSource,
 				crmProspectId,
@@ -137,7 +137,7 @@ export const actions: Actions = {
 			);
 		}
 		if (supabase) {
-			await updateDemoTrackingStatus(user.id, prospectId, {
+			await updateDemoTrackingStatus(prospectId, {
 				status: 'draft',
 				scrapedData
 			});
@@ -162,7 +162,7 @@ export const actions: Actions = {
 		if (!status || typeof status !== 'string' || !isValidDemoTrackingStatus(status)) {
 			return fail(400, { message: 'Invalid status' });
 		}
-		const result = await updateDemoTrackingStatus(user.id, prospectId, { status });
+		const result = await updateDemoTrackingStatus(prospectId, { status });
 		if (!result.ok) {
 			return fail(502, { message: result.error ?? 'Failed to update demo status' });
 		}
@@ -185,7 +185,7 @@ export const actions: Actions = {
 		}
 		for (const id of prospectIds) {
 			if (typeof id !== 'string') continue;
-			await updateDemoTrackingStatus(user.id, id, {
+			await updateDemoTrackingStatus(id, {
 				status: 'approved'
 			});
 		}
@@ -227,8 +227,9 @@ export const actions: Actions = {
 			const demoUrl = `${demoPublicOrigin}/demo/${prospectId}`;
 			const crmSource = prospect.provider ?? 'manual';
 			const crmProspectId = prospect.provider_row_id ?? prospectId;
-			await upsertDemoTrackingForProspect(user.id, prospectId, crmSource, crmProspectId, demoUrl, 'draft');
-			await updateDemoTrackingStatus(user.id, prospectId, { status: 'draft', scrapedData });
+			const trackingOwnerId = prospect.userId ?? user.id;
+			await upsertDemoTrackingForProspect(trackingOwnerId, prospectId, crmSource, crmProspectId, demoUrl, 'draft');
+			await updateDemoTrackingStatus(prospectId, { status: 'draft', scrapedData });
 			if (scrapedData?.gbpRaw && typeof scrapedData.gbpRaw === 'object') {
 				await updateProspectFromGbp(prospectId, scrapedData.gbpRaw as { phone?: string; website?: string; address?: string; industry?: string });
 			}

--- a/apps/admin/src/routes/dashboard/prospects/+page.server.ts
+++ b/apps/admin/src/routes/dashboard/prospects/+page.server.ts
@@ -11,7 +11,7 @@ import {
 import {
 	getSupabaseAdmin,
 	getDemoTrackingMapGlobal,
-	getDemoTrackingForProspect,
+	getDemoTrackingForProspectLatest,
 	getDemoCountThisMonth,
 	updateDemoTrackingStatus,
 	upsertDemoTrackingForProspect,
@@ -301,16 +301,17 @@ export const actions: Actions = {
 			return fail(502, { message: result.error ?? 'Failed to update prospect' });
 		}
 		const supabase = getSupabaseAdmin();
+		const trackingOwnerId = prospect.userId ?? user.id;
 		if (supabase) {
 			await upsertDemoTrackingForProspect(
-				user.id,
+				trackingOwnerId,
 				prospectId,
 				prospect.provider ?? 'manual',
 				prospect.provider_row_id ?? prospectId,
 				demoUrl,
 				'draft'
 			);
-			await updateDemoTrackingStatus(user.id, prospectId, {
+			await updateDemoTrackingStatus(prospectId, {
 				status: 'draft',
 				scrapedData
 			});
@@ -336,7 +337,7 @@ export const actions: Actions = {
 		if (!status || typeof status !== 'string' || !isValidDemoTrackingStatus(status)) {
 			return fail(400, { message: 'Invalid status' });
 		}
-		const result = await updateDemoTrackingStatus(user.id, prospectId, { status });
+		const result = await updateDemoTrackingStatus(prospectId, { status });
 		if (!result.ok) {
 			return fail(502, { message: result.error ?? 'Failed to update demo status' });
 		}
@@ -369,7 +370,7 @@ export const actions: Actions = {
 			return fail(503, { message: 'Could not queue regeneration. Try again.' });
 		}
 		// Regenerating always resets tracking to draft (was approved or draft); callback also sets draft on completion.
-		await updateDemoTrackingStatus(user.id, prospectId, { status: 'draft' });
+		await updateDemoTrackingStatus(prospectId, { status: 'draft' });
 		return { success: true, prospectId, queued: true, jobId: result.jobId, alreadyQueued: !result.created };
 	},
 	bulkApproveDemos: async (event) => {
@@ -389,7 +390,7 @@ export const actions: Actions = {
 		}
 		for (const id of prospectIds) {
 			if (typeof id !== 'string') continue;
-			await updateDemoTrackingStatus(user.id, id, {
+			await updateDemoTrackingStatus(id, {
 				status: 'approved'
 			});
 		}
@@ -468,17 +469,18 @@ export const actions: Actions = {
 			if (typeof id !== 'string') continue;
 			const prospect = await getProspectById(id);
 			if (!prospect?.demoLink || prospect.flagged) continue;
-			let demoTracking = await getDemoTrackingForProspect(user.id, id);
+			let demoTracking = await getDemoTrackingForProspectLatest(id);
 			if (!demoTracking && (prospect.demoLink ?? '').trim()) {
+				const trackingOwnerId = prospect.userId ?? user.id;
 				await upsertDemoTrackingForProspect(
-					user.id,
+					trackingOwnerId,
 					id,
 					prospect.provider ?? 'manual',
 					prospect.provider_row_id ?? id,
 					(prospect.demoLink ?? '').trim(),
 					'approved'
 				);
-				demoTracking = await getDemoTrackingForProspect(user.id, id);
+				demoTracking = await getDemoTrackingForProspectLatest(id);
 			}
 			if (
 				!demoTracking ||

--- a/apps/admin/src/routes/dashboard/prospects/[id]/+page.server.ts
+++ b/apps/admin/src/routes/dashboard/prospects/[id]/+page.server.ts
@@ -160,7 +160,7 @@ export const actions: Actions = {
 		if (!status || typeof status !== 'string' || !isValidDemoTrackingStatus(status)) {
 			return fail(400, { message: 'Invalid status' });
 		}
-		const result = await updateDemoTrackingStatus(user.id, prospectId, { status });
+		const result = await updateDemoTrackingStatus(prospectId, { status });
 		if (!result.ok) return fail(502, { message: result.error ?? 'Failed to update demo status' });
 		return { success: true, prospectId, status };
 	},
@@ -183,8 +183,9 @@ export const actions: Actions = {
 		let demoTracking = await getDemoTrackingForProspectLatest(prospectId);
 		if (!demoTracking) {
 			// Legacy: prospect has demo link but no demo_tracking row; create one as approved so Send is available
+			const trackingOwnerId = prospect.userId ?? user.id;
 			await upsertDemoTrackingForProspect(
-				user.id,
+				trackingOwnerId,
 				prospectId,
 				prospect.provider ?? 'manual',
 				prospect.provider_row_id ?? prospectId,
@@ -196,7 +197,7 @@ export const actions: Actions = {
 		if (demoTracking.status !== 'draft') {
 			return fail(400, { message: 'Demo is already approved or sent. No need to approve again.' });
 		}
-		const result = await updateDemoTrackingStatus(user.id, prospectId, { status: 'approved' });
+		const result = await updateDemoTrackingStatus(prospectId, { status: 'approved' });
 		if (!result.ok) return fail(502, { message: result.error ?? 'Failed to approve demo' });
 		return { success: true, prospectId };
 	},
@@ -225,7 +226,7 @@ export const actions: Actions = {
 			return fail(503, { message: 'Could not queue regeneration. Try again.' });
 		}
 		// Regenerating always resets tracking to draft (was approved or draft); callback also sets draft on completion.
-		await updateDemoTrackingStatus(user.id, prospectId, { status: 'draft' });
+		await updateDemoTrackingStatus(prospectId, { status: 'draft' });
 		return { success: true, prospectId, queued: true, jobId: result.jobId, alreadyQueued: !result.created };
 	},
 
@@ -318,8 +319,9 @@ export const actions: Actions = {
 				return fail(400, { message: 'No demo link or prospect out of scope.' });
 			}
 			if (!demoTracking && (prospect.demoLink ?? '').trim()) {
+				const trackingOwnerId = prospect.userId ?? user.id;
 				await upsertDemoTrackingForProspect(
-					user.id,
+					trackingOwnerId,
 					prospectId,
 					prospect.provider ?? 'manual',
 					prospect.provider_row_id ?? prospectId,

--- a/apps/admin/supabase/migrations/20260410120000_demo_tracking_align_user_id_to_prospect.sql
+++ b/apps/admin/supabase/migrations/20260410120000_demo_tracking_align_user_id_to_prospect.sql
@@ -1,0 +1,22 @@
+-- Align demo_tracking.user_id with prospects.user_id when linked by prospect_id.
+-- Fixes rows created under a teammate's session while the prospect owner differs (shared Ed & Sy dashboard).
+-- Skips updates that would violate unique (user_id, crm_source, crm_prospect_id) on another row.
+
+update public.demo_tracking as dt
+set
+  user_id = p.user_id,
+  updated_at = now()
+from public.prospects as p
+where
+  dt.prospect_id is not null
+  and dt.prospect_id = p.id
+  and dt.user_id is distinct from p.user_id
+  and not exists (
+    select 1
+    from public.demo_tracking dt2
+    where
+      dt2.id <> dt.id
+      and dt2.user_id = p.user_id
+      and dt2.crm_source = dt.crm_source
+      and dt2.crm_prospect_id = dt.crm_prospect_id
+  );

--- a/apps/admin/supabase/migrations_dev/20260410120000_demo_tracking_align_user_id_to_prospect.sql
+++ b/apps/admin/supabase/migrations_dev/20260410120000_demo_tracking_align_user_id_to_prospect.sql
@@ -1,0 +1,22 @@
+-- Twin of supabase/migrations/20260410120000_demo_tracking_align_user_id_to_prospect.sql targeting schema dev.
+-- Regenerate: pnpm run db:sync-migrations-dev
+-- Apply: pnpm run db:push:dev (with SUPABASE_DATABASE_URL)
+
+update dev.demo_tracking as dt
+set
+  user_id = p.user_id,
+  updated_at = now()
+from dev.prospects as p
+where
+  dt.prospect_id is not null
+  and dt.prospect_id = p.id
+  and dt.user_id is distinct from p.user_id
+  and not exists (
+    select 1
+    from dev.demo_tracking dt2
+    where
+      dt2.id <> dt.id
+      and dt2.user_id = p.user_id
+      and dt2.crm_source = dt.crm_source
+      and dt2.crm_prospect_id = dt.crm_prospect_id
+  );


### PR DESCRIPTION
Fixes #91

## Summary

- `updateDemoTrackingStatus` now updates the latest `demo_tracking` row for the prospect (same rule as the UI), verifies the update applied, and returns an error when no row exists.
- Upserts use `prospect.userId ?? session user` so new rows attach to the CRM prospect owner when a teammate acts on another user's prospect.
- Gmail send / draft revert use latest tracking per prospect instead of session-scoped lookup.
- GBP and Insights workers read latest tracking and use prospect owner when inserting missing rows.

## Migration

- `20260410120000_demo_tracking_align_user_id_to_prospect.sql` (and `migrations_dev` twin): align `demo_tracking.user_id` to `prospects.user_id` where `prospect_id` matches, skipping rows that would violate the unique constraint.

Production: migration was applied with `pnpm run db:push` before this PR.
