### PR TITLE
feat(admin): pipeline chart matches prospect status; clarify demo open labels

### DIFF
--- a/apps/admin/src/lib/constants/demoStatus.ts
+++ b/apps/admin/src/lib/constants/demoStatus.ts
@@ -40,8 +40,8 @@ export const DEMO_TRACKING_OPTIONS: { value: DemoTrackingStatus; label: string }
 	{ value: 'approved', label: 'Ready' },
 	{ value: 'email_draft', label: 'Outreach draft · Gmail' },
 	{ value: 'sent', label: 'Demo Sent' },
-	{ value: 'opened', label: 'Demo Opened · Email' },
-	{ value: 'clicked', label: 'Demo Opened · Link' },
+	{ value: 'opened', label: 'Email Opened' },
+	{ value: 'clicked', label: 'Demo Link Opened' },
 	{ value: 'replied', label: 'Follow-up' }
 ];
 

--- a/apps/admin/src/lib/dashboardPipeline.ts
+++ b/apps/admin/src/lib/dashboardPipeline.ts
@@ -1,0 +1,84 @@
+/**
+ * Dashboard home "Pipeline" chart: same buckets as the Prospects table Status column
+ * (getSimplifiedStatus), not raw prospects.status alone.
+ */
+
+import type { Prospect } from '$lib/server/prospects';
+import { getSimplifiedStatus, type ProspectNextStepInput, type SimplifiedStatusResult } from '$lib/nextStep';
+import { auditFromScrapedData, hasUsableInsight } from '$lib/demo';
+
+/** Bar labels on the dashboard Pipeline card (order matches UI). */
+export const DASHBOARD_PIPELINE_BAR_LABELS = [
+	'New',
+	'GBP Queued',
+	'Pending Demo',
+	'Demo Queued',
+	'Review',
+	'Ready to Send',
+	'Demo Sent',
+	'Demo Opened',
+	'Follow-up',
+	'Other'
+] as const;
+
+const PIPELINE_BAR_SET = new Set<string>(DASHBOARD_PIPELINE_BAR_LABELS);
+
+/** Map Status-column label (+ variant) to a pipeline bar. */
+export function mapSimplifiedStatusToPipelineBar(result: SimplifiedStatusResult): string {
+	if (result.variant === 'destructive') {
+		return 'Pending Demo';
+	}
+	const t = result.label.trim();
+	if (t === 'Email Opened' || t === 'Demo Link Opened') return 'Demo Opened';
+	if (t === 'Out of scope') return 'Other';
+	if (t === 'Ready to send') return 'Ready to Send';
+	if (t === 'Gmail draft') return 'Ready to Send';
+	if (t === 'Processing GBP') return 'GBP Queued';
+	if (t === 'Processing Demo') return 'Demo Queued';
+	if (t === 'Not contacted yet' || t === 'Not contacted') return 'New';
+	if (PIPELINE_BAR_SET.has(t)) return t;
+	return 'Other';
+}
+
+/**
+ * Build `{ status, count }[]` for the dashboard Pipeline card.
+ * Every prospect is counted exactly once (sums to prospects.length).
+ */
+export function buildDashboardPipelineChartData(
+	prospects: Prospect[],
+	demoTrackingByProspectId: Record<string, { status?: string } | undefined>,
+	gbpJobsByProspectId: Record<string, { status: string }>,
+	insightsJobsByProspectId: Record<string, { status: string }>,
+	demoJobsByProspectId: Record<string, { status: string; errorMessage?: string | null } | undefined>,
+	scrapedDataByProspectId: Record<string, Record<string, unknown>>
+): { status: string; count: number }[] {
+	const counts = new Map<string, number>();
+	for (const label of DASHBOARD_PIPELINE_BAR_LABELS) {
+		counts.set(label, 0);
+	}
+
+	for (const p of prospects) {
+		const scraped = scrapedDataByProspectId[p.id];
+		const audit = auditFromScrapedData(scraped ?? null);
+		const row: ProspectNextStepInput = {
+			id: p.id,
+			status: p.status,
+			flagged: p.flagged,
+			demoLink: p.demoLink,
+			gbpJob: gbpJobsByProspectId[p.id] ?? null,
+			insightsJob: insightsJobsByProspectId[p.id] ?? null,
+			demoJob: demoJobsByProspectId[p.id] ?? null,
+			tracking: demoTrackingByProspectId[p.id] ?? null
+		};
+		const simplified = getSimplifiedStatus(row, {
+			hasGbpData: audit ? hasUsableInsight(audit) : false
+		});
+		const bar = mapSimplifiedStatusToPipelineBar(simplified);
+		counts.set(bar, (counts.get(bar) ?? 0) + 1);
+	}
+
+	return DASHBOARD_PIPELINE_BAR_LABELS.map((status) => ({
+		status,
+		count: counts.get(status) ?? 0
+	}));
+}

--- a/apps/admin/src/lib/nextStep.ts
+++ b/apps/admin/src/lib/nextStep.ts
@@ -24,7 +24,7 @@ export interface ProspectNextStepInput {
 
 /**
  * Automation + outreach labels shown in the Status column.
- * Lifecycle labels: New → GBP Queued → Processing GBP → Pending Demo → Demo Queued → Processing Demo → Ready to send → Demo Sent → Demo Opened → Follow-up (see getStatusDisplay + jobs).
+ * Lifecycle labels: New → GBP Queued → Processing GBP → Pending Demo → Demo Queued → Processing Demo → Ready to send → Demo Sent → Email Opened / Demo Link Opened → Follow-up (see getStatusDisplay + jobs).
  */
 export type SimplifiedStatusLabel = string;
 
@@ -112,8 +112,11 @@ export function getSimplifiedStatus(
 	if (trackingStatus === 'sent') {
 		return { label: 'Demo Sent', variant: 'muted' };
 	}
-	if (trackingStatus === 'opened' || trackingStatus === 'clicked') {
-		return { label: 'Demo Opened', variant: 'success' };
+	if (trackingStatus === 'opened') {
+		return { label: 'Email Opened', variant: 'success' };
+	}
+	if (trackingStatus === 'clicked') {
+		return { label: 'Demo Link Opened', variant: 'success' };
 	}
 	if (trackingStatus === 'replied') {
 		return { label: 'Follow-up', variant: 'success' };
@@ -218,10 +221,10 @@ export function getNextStep(
 		return { label: 'Demo Sent', variant: 'muted', filterValue: 'sent' };
 	}
 	if (trackingStatus === 'opened') {
-		return { label: 'Demo Opened', variant: 'success', filterValue: 'engaged' };
+		return { label: 'Email Opened', variant: 'success', filterValue: 'engaged' };
 	}
 	if (trackingStatus === 'clicked') {
-		return { label: 'Demo Opened', variant: 'success', filterValue: 'engaged' };
+		return { label: 'Demo Link Opened', variant: 'success', filterValue: 'engaged' };
 	}
 	if (trackingStatus === 'replied') {
 		return { label: 'Follow-up', variant: 'success', filterValue: 'replied' };

--- a/apps/admin/src/routes/dashboard/+page.server.ts
+++ b/apps/admin/src/routes/dashboard/+page.server.ts
@@ -15,7 +15,12 @@ import {
 	getPlacesMonthlyLimit,
 	updateDemoTrackingStatus,
 	upsertDemoTrackingForProspect,
-	enqueueDemoJob
+	enqueueDemoJob,
+	getDemoTrackingMapGlobal,
+	getGbpJobsMapGlobal,
+	getInsightsJobsMapGlobal,
+	getDemoJobsMapGlobal,
+	getScrapedDataMapGlobal
 } from '$lib/server/supabase';
 import { getScrapedDataForDemo, formatScrapedDataErrorMessage } from '$lib/server/gbp';
 import type { PageServerLoad, Actions } from './$types';
@@ -25,42 +30,45 @@ import { getGbpDefaultLocation } from '$lib/server/userSettings';
 import { isValidDemoTrackingStatus } from '$lib/demo';
 import { getOriginForOutgoingLinks, getDemoPublicOrigin } from '$lib/server/send';
 import { PROSPECT_STATUS } from '$lib/prospectStatus';
+import { buildDashboardPipelineChartData } from '$lib/dashboardPipeline';
 export const load: PageServerLoad = async (event) => {
 	const user = await getDashboardSessionUser(event);
 	if (!user) {
 		throw redirect(303, '/auth/login');
 	}
-	const [demoCountThisMonth, gbpCountThisMonth, insightsCountThisMonth, placesCountThisMonth, prospectsResult] =
-		await Promise.all([
-			getDemoCountThisMonth(user.id),
-			getGbpCountThisMonth(user.id),
-			getInsightsCountThisMonth(user.id),
-			getPlacesCountThisMonth(),
-			listProspects()
-		]);
+	const [
+		demoCountThisMonth,
+		gbpCountThisMonth,
+		insightsCountThisMonth,
+		placesCountThisMonth,
+		prospectsResult,
+		demoTrackingByProspectId,
+		scrapedDataByProspectId,
+		demoJobsByProspectId,
+		gbpJobsByProspectId,
+		insightsJobsByProspectId
+	] = await Promise.all([
+		getDemoCountThisMonth(user.id),
+		getGbpCountThisMonth(user.id),
+		getInsightsCountThisMonth(user.id),
+		getPlacesCountThisMonth(),
+		listProspects(),
+		getDemoTrackingMapGlobal(),
+		getScrapedDataMapGlobal(),
+		getDemoJobsMapGlobal(),
+		getGbpJobsMapGlobal(),
+		getInsightsJobsMapGlobal()
+	]);
 	const placesMonthlyLimit = getPlacesMonthlyLimit();
 	const prospects = prospectsResult.prospects ?? [];
-	const statusOrder: Array<{ key: string; label: string }> = [
-		{ key: PROSPECT_STATUS.NEW, label: 'New' },
-		{ key: PROSPECT_STATUS.GBP_QUEUED, label: 'GBP Queued' },
-		{ key: PROSPECT_STATUS.DEMO_PENDING, label: 'Pending Demo' },
-		{ key: PROSPECT_STATUS.DEMO_QUEUED, label: 'Demo Queued' },
-		{ key: PROSPECT_STATUS.REVIEW, label: 'Review' },
-		{ key: PROSPECT_STATUS.READY_TO_SEND, label: 'Ready to Send' },
-		{ key: PROSPECT_STATUS.EMAIL_SENT, label: 'Demo Sent' },
-		{ key: PROSPECT_STATUS.DEMO_OPENED, label: 'Demo Opened' },
-		{ key: PROSPECT_STATUS.FOLLOW_UP, label: 'Follow-up' }
-	];
-	const statusCounts = new Map<string, number>();
-	for (const p of prospects) {
-		const key = (p.status ?? '').trim().toLowerCase();
-		if (!key) continue;
-		statusCounts.set(key, (statusCounts.get(key) ?? 0) + 1);
-	}
-	const statusChartData = statusOrder.map((s) => ({
-		status: s.label,
-		count: statusCounts.get(s.key.toLowerCase()) ?? 0
-	}));
+	const statusChartData = buildDashboardPipelineChartData(
+		prospects,
+		demoTrackingByProspectId,
+		gbpJobsByProspectId,
+		insightsJobsByProspectId,
+		demoJobsByProspectId,
+		scrapedDataByProspectId
+	);
 
 	const attentionStatusKeys = new Set(
 		[

--- a/apps/admin/src/routes/dashboard/+page.svelte
+++ b/apps/admin/src/routes/dashboard/+page.svelte
@@ -279,8 +279,8 @@
 				<div>
 					<h2 class="text-lg font-semibold tracking-tight">Pipeline</h2>
 					<p class="text-sm text-muted-foreground">
-						Prospects grouped by CRM status, in workflow order. Bar length is relative to the busiest stage on
-						this list.
+						Prospects grouped the same way as the Status column on Prospects (workflow state, including demo
+						tracking and jobs). Bar length is relative to the busiest stage on this list.
 					</p>
 				</div>
 				<Card.Root class="border-border/80 shadow-sm">

--- a/apps/admin/src/routes/dashboard/prospects/[id]/+page.svelte
+++ b/apps/admin/src/routes/dashboard/prospects/[id]/+page.svelte
@@ -215,10 +215,10 @@
 			pushEvent('sent', 'Demo sent', demoTracking.send_time);
 		}
 		if (demoTracking?.opened_at) {
-			pushEvent('opened', 'Demo opened (email)', demoTracking.opened_at);
+			pushEvent('opened', 'Email Opened', demoTracking.opened_at);
 		}
 		if (demoTracking?.clicked_at) {
-			pushEvent('clicked', 'Demo opened (link click)', demoTracking.clicked_at);
+			pushEvent('clicked', 'Demo Link Opened', demoTracking.clicked_at);
 		}
 		if (demoTracking?.status === 'replied') {
 			pushEvent('follow_up', 'Follow-up / replied', demoTracking.updated_at ?? null);


### PR DESCRIPTION
## Summary

This updates the admin dashboard pipeline card to use the same simplified status logic as the Prospects table (`getSimplifiedStatus`), via `buildDashboardPipelineChartData` and the new `dashboardPipeline` module.

It also renames demo tracking engagement copy to **Email Opened** and **Demo Link Opened** everywhere that previously showed combined or parenthetical demo-open wording (Status column, next-step labels, stage dropdown, prospect detail timeline, and pipeline bar aggregation).

## Testing

- Not run in CI from this environment; please spot-check dashboard pipeline counts against the prospects table filters.

Closes #97
